### PR TITLE
Storage of Standard-based Data

### DIFF
--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -13,8 +13,7 @@ import SwiftUI
 struct ExampleAppStandard: Standard {}
 
 
-// swiftlint:disable:next generic_type_name
-class ExampleAppComponent<ResourceRepresentation: Standard>: Component, LifecycleHandler, ObservableObjectComponent, ObservableObject, StorageKey {
+class ExampleAppComponent<ComponentStandard: Standard>: Module {
     var greeting: String
     
     

--- a/Sources/CardinalKit/CardinalKitAppDelegate.swift
+++ b/Sources/CardinalKit/CardinalKitAppDelegate.swift
@@ -45,6 +45,7 @@ open class CardinalKitAppDelegate: NSObject, UIApplicationDelegate {
     
     open func application(
         _ application: UIApplication,
+        // The usage of an optional collection is impossible to avoid as the function signature is defined by the `UIApplicationDelegate`
         // swiftlint:disable:next discouraged_optional_collection
         willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {

--- a/Sources/CardinalKit/Component.swift
+++ b/Sources/CardinalKit/Component.swift
@@ -9,8 +9,8 @@
 
 /// A ``Component`` defines
 public protocol Component: _AnyComponent {
-    /// A ``Component/ResourceRepresentation`` defines what ``Standard`` the component supports.
-    associatedtype ResourceRepresentation: Standard
+    /// A ``Component/ComponentStandard`` defines what ``Standard`` the component supports.
+    associatedtype ComponentStandard: Standard
     
     
     /// The ``Component/configure(cardinalKit:)`` method is called on the initialization of the CardinalKit instance to perform a lightweight configuration of the component.
@@ -18,14 +18,15 @@ public protocol Component: _AnyComponent {
     /// If a ``Component`` needs to store a reference to the ``CardinalKit`` instance, it should keep a **weak** reference to the ``CardinalKit`` instance.
     /// It is advised that longer setup tasks are done in an asynchronous task and started during the call of the configure method.
     /// - Parameter cardinalKit: The ``CardinalKit`` instance used in the instance of a CardinalKit project.
-    func configure(cardinalKit: CardinalKit<ResourceRepresentation>)
+    func configure(cardinalKit: CardinalKit<ComponentStandard>)
 }
 
 
 extension Component {
+    // A documentation for this methodd exists in the `_AnyComponent` type which SwiftLint doesn't recognize.
     // swiftlint:disable:next missing_docs
     public func configureAny(cardinalKit: Any) {
-        guard let typedCardinalKit = cardinalKit as? CardinalKit<ResourceRepresentation> else {
+        guard let typedCardinalKit = cardinalKit as? CardinalKit<ComponentStandard> else {
             return
         }
         
@@ -37,8 +38,10 @@ extension Component {
 extension Component where Self: StorageKey {
     typealias Value = Self
     
+    
+    // A documentation for this methodd exists in the `Component` type which SwiftLint doesn't recognize.
     // swiftlint:disable:next missing_docs
-    public func configure(cardinalKit: CardinalKit<ResourceRepresentation>) {
+    public func configure(cardinalKit: CardinalKit<ComponentStandard>) {
         cardinalKit.storage.set(Self.self, to: self as? Self.Value)
     }
 }

--- a/Sources/CardinalKit/ComponentBuilder.swift
+++ b/Sources/CardinalKit/ComponentBuilder.swift
@@ -10,7 +10,7 @@
 @resultBuilder
 public enum ComponentBuilder<S: Standard> {
     /// If declared, provides contextual type information for statement expressions to translate them into partial results.
-    public static func buildExpression<C: Component>(_ expression: C) -> [_AnyComponent] where C.ResourceRepresentation == S {
+    public static func buildExpression<C: Component>(_ expression: C) -> [_AnyComponent] where C.ComponentStandard == S {
         [expression]
     }
     
@@ -21,6 +21,7 @@ public enum ComponentBuilder<S: Standard> {
     
     /// Enables support for `if` statements that do not have an `else`.
     public static func buildOptional(_ component: [_AnyComponent]?) -> [_AnyComponent] { // swiftlint:disable:this discouraged_optional_collection
+        // The optional collection is a requirement defined by @resultBuilder, we can not use a non-optional collection here.
         component ?? []
     }
 

--- a/Sources/CardinalKit/LifecycleHandler.swift
+++ b/Sources/CardinalKit/LifecycleHandler.swift
@@ -35,12 +35,14 @@ public protocol LifecycleHandler {
 
 
 extension LifecycleHandler {
+    // A documentation for this methodd exists in the `LifecycleHandler` type which SwiftLint doesn't recognize.
     // swiftlint:disable:next missing_docs
     public func willFinishLaunchingWithOptions(
         _ application: UIApplication,
         launchOptions: [UIApplication.LaunchOptionsKey: Any]
     ) { }
     
+    // A documentation for this methodd exists in the `LifecycleHandler` type which SwiftLint doesn't recognize.
     // swiftlint:disable:next missing_docs
     public func applicationWillTerminate(
         _ application: UIApplication

--- a/Sources/CardinalKit/Module.swift
+++ b/Sources/CardinalKit/Module.swift
@@ -1,0 +1,13 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+/// A ``Module`` is a larger ``Component`` that is a ``LifecycleHandler``, persisted in the ``CardinalKit`` instance's ``CardinalKit/CardinalKit/storage`` (using a conformance to ``StorageKey``), and injected in the SwiftUI view hierachy (``ObservableObjectComponent`` & ``ObservableObject``).
+public typealias Module = Component & LifecycleHandler & ObservableObjectComponent & ObservableObject & StorageKey

--- a/Sources/CardinalKit/ObservableObjectComponent.swift
+++ b/Sources/CardinalKit/ObservableObjectComponent.swift
@@ -30,6 +30,7 @@ public protocol ObservableObjectComponent: _AnyObservableObjectComponent {
 
 
 extension ObservableObjectComponent where Self: ObservableObject {
+    // A documentation for this methodd exists in the `_AnyObservableObjectComponent` type which SwiftLint doesn't recognize.
     // swiftlint:disable:next missing_docs
     public var observableObject: Self {
         self
@@ -38,6 +39,7 @@ extension ObservableObjectComponent where Self: ObservableObject {
 
 
 extension ObservableObjectComponent {
+    // A documentation for this methodd exists in the `ObservableObjectComponent` type which SwiftLint doesn't recognize.
     // swiftlint:disable:next missing_docs
     public var viewModifier: any ViewModifier {
         ObservableObjectInjectionViewModifier(observableObject: observableObject)

--- a/Tests/CardinalKitTests/SharedTypes/TestConfiguration.swift
+++ b/Tests/CardinalKitTests/SharedTypes/TestConfiguration.swift
@@ -12,7 +12,7 @@ import XCTest
 
 
 struct TestComponent<S: Standard>: Component, ObservableObjectComponent, StorageKey, Equatable {
-    typealias ResourceRepresentation = S
+    typealias ComponentStandard = S
     
     
     class TestObservableObject: ObservableObject {}
@@ -26,7 +26,7 @@ struct TestComponent<S: Standard>: Component, ObservableObjectComponent, Storage
     }
     
     
-    func configure(cardinalKit: CardinalKit<ResourceRepresentation>) {
+    func configure(cardinalKit: CardinalKit<ComponentStandard>) {
         cardinalKit.storage.set(TestComponent.self, to: self)
         expectation.fulfill()
     }


### PR DESCRIPTION
# Storage of Standard-based Data

## :recycle: Current situation & Problem
Each CardinalKit application needs to persist data conforming to a `Standard` to process the data locally or until it is uploaded to a cloud storage provider. A CardinalKit Storage Module should provide this functionality to CardinalKit application developers.

## :bulb: Proposed solution
The PR introduced a local Storage Module that stores data locally.

## :gear: Release Notes 
- Introduced the `Module` type combining multiple requirements for `Component`s
- Introduces a local storage module that can be used across different CardinalKit applications.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).