### PR TITLE
Define a SecureStorage StorageScope

### DIFF
--- a/Sources/CardinalKit/Helper/Assert.swift
+++ b/Sources/CardinalKit/Helper/Assert.swift
@@ -42,7 +42,7 @@
 ///   - line: The line number to print along with `message` if the assertion
 ///     fails. The default is the line number where `assert(_:_:file:line:)`
 ///     is called.
-func assert(
+public func assert(
     _ condition: @autoclosure () -> Bool,
     _ message: @autoclosure () -> String = String(),
     file: StaticString = #file,
@@ -78,7 +78,7 @@ func assert(
 ///   - line: The line number to print along with `message` if the assertion
 ///     fails. The default is the line number where
 ///     `precondition(_:_:file:line:)` is called.
-func precondition(
+public func precondition(
     _ condition: @autoclosure () -> Bool,
     _ message: @autoclosure () -> String = String(),
     file: StaticString = #file,
@@ -108,7 +108,7 @@ func precondition(
 ///     where `assertionFailure(_:file:line:)` is called.
 ///   - line: The line number to print along with `message`. The default is the
 ///     line number where `assertionFailure(_:file:line:)` is called.
-func assertionFailure(
+public func assertionFailure(
     _ message: @autoclosure () -> String = String(),
     file: StaticString = #file,
     line: UInt = #line

--- a/Sources/SecureStorage/Credentials.swift
+++ b/Sources/SecureStorage/Credentials.swift
@@ -7,16 +7,24 @@
 //
 
 
+/// Credentials that can be stored, updated, deleted, and retrieved from a ``SecureStorage``.
 public struct Credentials: Equatable, Identifiable {
+    /// The username
     public var username: String
+    /// The password associated to the ``Credentials/username``
     public var password: String
     
     
+    /// Identifier of the ``Credentials`` representing the ``Credentials/username``
     public var id: String {
         username
     }
     
     
+    /// Credentials that can be stored, updated, deleted, and retrieved from a ``SecureStorage``.
+    /// - Parameters:
+    ///   - username: The username
+    ///   - password: The password associated to the ``Credentials/username``
     public init(username: String, password: String) {
         self.username = username
         self.password = password

--- a/Sources/SecureStorage/SecureStorage.swift
+++ b/Sources/SecureStorage/SecureStorage.swift
@@ -19,7 +19,8 @@ import Security
 public class SecureStorage<ComponentStandard: Standard>: Module {
     /// The ``SecureStorage`` serves as a resuable ``Module`` that can be used to store store small chunks of data such as credentials and keys.
     ///
-    /// The storing of credentials and keys follows the Keychain documentation provided by Apple: https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets.
+    /// The storing of credentials and keys follows the Keychain documentation provided by Apple:
+    /// https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets.
     public init() {}
     
     
@@ -131,8 +132,10 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
     /// - Parameters:
     ///   - credentials: The ``Credentials`` stored in the Keychain.
     ///   - server: The server associated with the credentials.
-    ///   - removeDuplicate: A flag indicating if any existing key for the `username` and `server` combination should be overwritten when storing the credentials.
-    ///   - storageScope: The ``StorageScope`` of the stored credentials. The ``StorageScope/secureEnclave(userPresence:)`` option is not supported for credentials.
+    ///   - removeDuplicate: A flag indicating if any existing key for the `username` and `server`
+    ///                      combination should be overwritten when storing the credentials.
+    ///   - storageScope: The ``StorageScope`` of the stored credentials.
+    ///                   The ``StorageScope/secureEnclave(userPresence:)`` option is not supported for credentials.
     public func store(
         credentials: Credentials,
         server: String? = nil,
@@ -180,7 +183,8 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
     ///   - server: The server associated with the old credentials.
     ///   - newCredentials: The new ``Credentials`` that should be stored in the Keychain.
     ///   - newServer: The server associated with the new credentials.
-    ///   - removeDuplicate: A flag indicating if any existing key for the `username` of the new credentials and `newServer` combination should be overwritten when storing the credentials.
+    ///   - removeDuplicate: A flag indicating if any existing key for the `username` of the new credentials and `newServer`
+    ///                      combination should be overwritten when storing the credentials.
     ///   - storageScope: The ``StorageScope`` of the newly stored credentials.
     public func updateCredentials( // swiftlint:disable:this function_default_parameter_at_end
         // The server parameter belongs to the `username` and therefore should be located next to the `username`.

--- a/Sources/SecureStorage/SecureStorage.swift
+++ b/Sources/SecureStorage/SecureStorage.swift
@@ -17,41 +17,23 @@ import Security
 ///
 /// The storing of credentials and keys follows the Keychain documentation provided by Apple: https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets.
 public class SecureStorage<ComponentStandard: Standard>: Module {
-    private let accessGroup: String?
-    private let synchronizable: Bool
-    
-    
-    public init(accessGroup: String? = nil, synchronizable: Bool = false) {
-        self.accessGroup = accessGroup
-        self.synchronizable = synchronizable
-    }
-    
+    /// <#Description#>
+    public init() {}
     
     // MARK: Key Handling
     
+    /// <#Description#>
+    /// - Parameters:
+    ///   - tag: <#tag description#>
+    ///   - size: <#size description#>
+    ///   - userPresence: <#userPresence description#>
+    /// - Returns: <#description#>
     @discardableResult
-    public func createKey(_ tag: String, size: Int = 256, userPresence: Bool = false) throws -> SecKey {
+    public func createKey(_ tag: String, size: Int = 256, storageScope: StorageScope = .secureEnclave) throws -> SecKey {
         // The key generation code follows
         // https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/protecting_keys_with_the_secure_enclave
         // and
         // https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/generating_new_cryptographic_keys
-        var secAccessControlCreateFlags: SecAccessControlCreateFlags = [.privateKeyUsage]
-        let protection: CFTypeRef
-        if userPresence {
-            secAccessControlCreateFlags.insert(.userPresence)
-            protection = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-        } else {
-            protection = kSecAttrAccessibleAfterFirstUnlock
-        }
-        
-        guard let access = SecAccessControlCreateWithFlags(
-            kCFAllocatorDefault,
-            protection,
-            secAccessControlCreateFlags,
-            nil
-        ) else {
-            throw SecureStorageError.createFailed()
-        }
         
         var attributes: [String: Any] = [
             kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
@@ -60,7 +42,7 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
             kSecPrivateKeyAttrs as String: [
                 kSecAttrIsPermanent as String: true,
                 kSecAttrApplicationTag as String: Data(tag.utf8),
-                kSecAttrAccessControl as String: access
+                kSecAttrAccessControl as String: try storageScope.accessControl
             ]
         ]
         
@@ -79,6 +61,9 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
         return publicKey
     }
     
+    /// <#Description#>
+    /// - Parameter tag: <#tag description#>
+    /// - Returns: <#description#>
     public func retrievePrivateKey(forTag tag: String) throws -> SecKey? {
         // This method follows
         // https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/storing_keys_in_the_keychain
@@ -99,6 +84,9 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
         return (item as! SecKey) // swiftlint:disable:this force_cast
     }
     
+    /// <#Description#>
+    /// - Parameter tag: <#tag description#>
+    /// - Returns: <#description#>
     public func retrievePublicKey(forTag tag: String) throws -> SecKey? {
         guard let privateKey = try retrievePrivateKey(forTag: tag),
               let publicKey = SecKeyCopyPublicKey(privateKey) else {
@@ -108,6 +96,8 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
         return publicKey
     }
     
+    /// <#Description#>
+    /// - Parameter tag: <#tag description#>
     public func deleteKeys(forTag tag: String) throws {
         do {
             try execute(SecItemDelete(keyQuery(forTag: tag) as CFDictionary))
@@ -130,13 +120,27 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
     
     // MARK: Credentials Handling
     
-    public func store(credentials: Credentials, server: String? = nil, removeDuplicate: Bool = true) throws {
+    /// <#Description#>
+    /// - Parameters:
+    ///   - credentials: <#credentials description#>
+    ///   - server: <#server description#>
+    ///   - removeDuplicate: <#removeDuplicate description#>
+    ///   - storageScope: <#storageScope description#>
+    public func store(
+        credentials: Credentials,
+        server: String? = nil,
+        removeDuplicate: Bool = true,
+        storageScope: StorageScope = .secureEnclave
+    ) throws {
         // This method uses code provided by the Apple Developer documentation at
         // https://developer.apple.com/documentation/security/keychain_services/keychain_items/adding_a_password_to_the_keychain.
         
-        var query = queryFor(credentials.username, server: server)
+        var query = queryFor(credentials.username, server: server, accessGroup: storageScope.accessGroup)
         query[kSecValueData as String] = Data(credentials.password.utf8)
-        query[kSecAttrSynchronizable as String] = synchronizable as CFBoolean
+        query[kSecAttrAccessControl as String] = try storageScope.accessControl
+        if case .keychainSynchronizable = storageScope {
+            query[kSecAttrSynchronizable as String] = true as CFBoolean
+        }
         
         do {
             try execute(SecItemAdd(query as CFDictionary, nil))
@@ -148,29 +152,46 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
         }
     }
     
-    public func deleteCredentials(_ username: String, server: String? = nil) throws {
-        let query = queryFor(username, server: server)
+    /// <#Description#>
+    /// - Parameters:
+    ///   - username: <#username description#>
+    ///   - server: <#server description#>
+    public func deleteCredentials(_ username: String, server: String? = nil, accessGroup: String? = nil) throws {
+        let query = queryFor(username, server: server, accessGroup: accessGroup)
         
         try execute(SecItemDelete(query as CFDictionary))
     }
     
+    /// <#Description#>
+    /// - Parameters:
+    ///   - username: <#username description#>
+    ///   - server: <#server description#>
+    ///   - newCredentials: <#newCredentials description#>
+    ///   - newServer: <#newServer description#>
+    ///   - removeDuplicate: <#removeDuplicate description#>
     public func updateCredentials( // swiftlint:disable:this function_default_parameter_at_end
         // The server parameter belongs to the `username` and therefore should be located next to the `username`.
         _ username: String,
         server: String? = nil,
         newCredentials: Credentials,
         newServer: String? = nil,
-        removeDuplicate: Bool = true
+        removeDuplicate: Bool = true,
+        storageScope: StorageScope = .secureEnclave
     ) throws {
         try deleteCredentials(username, server: server)
-        try store(credentials: newCredentials, server: newServer, removeDuplicate: removeDuplicate)
+        try store(credentials: newCredentials, server: newServer, removeDuplicate: removeDuplicate, storageScope: storageScope)
     }
     
-    public func retrieveCredentials(_ username: String, server: String? = nil) throws -> Credentials? {
+    /// <#Description#>
+    /// - Parameters:
+    ///   - username: <#username description#>
+    ///   - server: <#server description#>
+    /// - Returns: <#description#>
+    public func retrieveCredentials(_ username: String, server: String? = nil, accessGroup: String? = nil) throws -> Credentials? {
         // This method uses code provided by the Apple Developer documentation at
         // https://developer.apple.com/documentation/security/keychain_services/keychain_items/searching_for_keychain_items
         
-        var query: [String: Any] = queryFor(username, server: server)
+        var query: [String: Any] = queryFor(username, server: server, accessGroup: accessGroup)
         query[kSecMatchLimit as String] = kSecMatchLimitOne
         query[kSecReturnAttributes as String] = true
         query[kSecReturnData as String] = true
@@ -209,7 +230,7 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
         }
     }
     
-    private func queryFor(_ account: String, server: String?) -> [String: Any] {
+    private func queryFor(_ account: String, server: String?, accessGroup: String?) -> [String: Any] {
         // This method uses code provided by the Apple Developer documentation at
         // https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets
         

--- a/Sources/SecureStorage/SecureStorage.swift
+++ b/Sources/SecureStorage/SecureStorage.swift
@@ -17,17 +17,20 @@ import Security
 ///
 /// The storing of credentials and keys follows the Keychain documentation provided by Apple: https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets.
 public class SecureStorage<ComponentStandard: Standard>: Module {
-    /// <#Description#>
+    /// The ``SecureStorage`` serves as a resuable ``Module`` that can be used to store store small chunks of data such as credentials and keys.
+    ///
+    /// The storing of credentials and keys follows the Keychain documentation provided by Apple: https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets.
     public init() {}
     
-    // MARK: Key Handling
     
-    /// <#Description#>
+    // MARK: - Key Handling
+    
+    /// Create a `ECSECPrimeRandom` key for a specified size.
     /// - Parameters:
-    ///   - tag: <#tag description#>
-    ///   - size: <#size description#>
-    ///   - userPresence: <#userPresence description#>
-    /// - Returns: <#description#>
+    ///   - tag: The tag used to identify the key in the keychain or the secure enclave.
+    ///   - size: The size of the key in bits. The default value is 256 bits.
+    ///   - storageScope: The  ``StorageScope`` used to store the newly generate key.
+    /// - Returns: Returns the `SecKey` generated and stored in the keychain or the secure enclave.
     @discardableResult
     public func createKey(_ tag: String, size: Int = 256, storageScope: StorageScope = .secureEnclave) throws -> SecKey {
         // The key generation code follows
@@ -35,15 +38,19 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
         // and
         // https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/generating_new_cryptographic_keys
         
+        var privateKeyAttrs: [String: Any] = [
+            kSecAttrIsPermanent as String: true,
+            kSecAttrApplicationTag as String: Data(tag.utf8)
+        ]
+        if let accessControl = try storageScope.accessControl {
+            privateKeyAttrs[kSecAttrAccessControl as String] = accessControl
+        }
+        
         var attributes: [String: Any] = [
             kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
             kSecAttrKeySizeInBits as String: size as CFNumber,
             kSecAttrTokenID as String: kSecAttrTokenIDSecureEnclave,
-            kSecPrivateKeyAttrs as String: [
-                kSecAttrIsPermanent as String: true,
-                kSecAttrApplicationTag as String: Data(tag.utf8),
-                kSecAttrAccessControl as String: try storageScope.accessControl
-            ]
+            kSecPrivateKeyAttrs as String: privateKeyAttrs
         ]
         
         // Check that the device has a Secure Enclave
@@ -61,9 +68,9 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
         return publicKey
     }
     
-    /// <#Description#>
-    /// - Parameter tag: <#tag description#>
-    /// - Returns: <#description#>
+    /// Retrieves a private key stored in the keychain or the secure enclave identified by a `tag`.
+    /// - Parameter tag: The tag used to identify the key in the keychain or the secure enclave.
+    /// - Returns: Returns the private `SecKey` generated and stored in the keychain or the secure enclave.
     public func retrievePrivateKey(forTag tag: String) throws -> SecKey? {
         // This method follows
         // https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/storing_keys_in_the_keychain
@@ -84,9 +91,9 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
         return (item as! SecKey) // swiftlint:disable:this force_cast
     }
     
-    /// <#Description#>
-    /// - Parameter tag: <#tag description#>
-    /// - Returns: <#description#>
+    /// Retrieves a public key stored in the keychain or the secure enclave identified by a `tag`.
+    /// - Parameter tag: The tag used to identify the key in the keychain or the secure enclave.
+    /// - Returns: Returns the public `SecKey` generated and stored in the keychain or the secure enclave.
     public func retrievePublicKey(forTag tag: String) throws -> SecKey? {
         guard let privateKey = try retrievePrivateKey(forTag: tag),
               let publicKey = SecKeyCopyPublicKey(privateKey) else {
@@ -96,8 +103,8 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
         return publicKey
     }
     
-    /// <#Description#>
-    /// - Parameter tag: <#tag description#>
+    /// Deletes the key stored in the keychain or the secure enclave identified by a `tag`.
+    /// - Parameter tag: The tag used to identify the key in the keychain or the secure enclave.
     public func deleteKeys(forTag tag: String) throws {
         do {
             try execute(SecItemDelete(keyQuery(forTag: tag) as CFDictionary))
@@ -118,28 +125,32 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
     }
     
     
-    // MARK: Credentials Handling
+    // MARK: - Credentials Handling
     
-    /// <#Description#>
+    /// Stores credentials in the Keychain.
     /// - Parameters:
-    ///   - credentials: <#credentials description#>
-    ///   - server: <#server description#>
-    ///   - removeDuplicate: <#removeDuplicate description#>
-    ///   - storageScope: <#storageScope description#>
+    ///   - credentials: The ``Credentials`` stored in the Keychain.
+    ///   - server: The server associated with the credentials.
+    ///   - removeDuplicate: A flag indicating if any existing key for the `username` and `server` combination should be overwritten when storing the credentials.
+    ///   - storageScope: The ``StorageScope`` of the stored credentials. The ``StorageScope/secureEnclave(userPresence:)`` option is not supported for credentials.
     public func store(
         credentials: Credentials,
         server: String? = nil,
         removeDuplicate: Bool = true,
-        storageScope: StorageScope = .secureEnclave
+        storageScope: StorageScope = .keychain
     ) throws {
         // This method uses code provided by the Apple Developer documentation at
         // https://developer.apple.com/documentation/security/keychain_services/keychain_items/adding_a_password_to_the_keychain.
         
+        assert(!(.secureEnclave ~= storageScope), "Storing of keys in the secure enclave is not supported by Apple.")
+        
         var query = queryFor(credentials.username, server: server, accessGroup: storageScope.accessGroup)
         query[kSecValueData as String] = Data(credentials.password.utf8)
-        query[kSecAttrAccessControl as String] = try storageScope.accessControl
+        
         if case .keychainSynchronizable = storageScope {
             query[kSecAttrSynchronizable as String] = true as CFBoolean
+        } else if let accessControl = try storageScope.accessControl {
+            query[kSecAttrAccessControl as String] = accessControl
         }
         
         do {
@@ -152,23 +163,25 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
         }
     }
     
-    /// <#Description#>
+    /// Delete existing credentials stored in the Keychain.
     /// - Parameters:
-    ///   - username: <#username description#>
-    ///   - server: <#server description#>
+    ///   - username: The username associated with the credentials.
+    ///   - server: The server associated with the credentials.
+    ///   - accessGroup: The access group associated with the credentials.
     public func deleteCredentials(_ username: String, server: String? = nil, accessGroup: String? = nil) throws {
         let query = queryFor(username, server: server, accessGroup: accessGroup)
         
         try execute(SecItemDelete(query as CFDictionary))
     }
     
-    /// <#Description#>
+    /// Update existing credentials found in the Keychain.
     /// - Parameters:
-    ///   - username: <#username description#>
-    ///   - server: <#server description#>
-    ///   - newCredentials: <#newCredentials description#>
-    ///   - newServer: <#newServer description#>
-    ///   - removeDuplicate: <#removeDuplicate description#>
+    ///   - username: The username associated with the old credentials.
+    ///   - server: The server associated with the old credentials.
+    ///   - newCredentials: The new ``Credentials`` that should be stored in the Keychain.
+    ///   - newServer: The server associated with the new credentials.
+    ///   - removeDuplicate: A flag indicating if any existing key for the `username` of the new credentials and `newServer` combination should be overwritten when storing the credentials.
+    ///   - storageScope: The ``StorageScope`` of the newly stored credentials.
     public func updateCredentials( // swiftlint:disable:this function_default_parameter_at_end
         // The server parameter belongs to the `username` and therefore should be located next to the `username`.
         _ username: String,
@@ -176,17 +189,18 @@ public class SecureStorage<ComponentStandard: Standard>: Module {
         newCredentials: Credentials,
         newServer: String? = nil,
         removeDuplicate: Bool = true,
-        storageScope: StorageScope = .secureEnclave
+        storageScope: StorageScope = .keychain
     ) throws {
         try deleteCredentials(username, server: server)
         try store(credentials: newCredentials, server: newServer, removeDuplicate: removeDuplicate, storageScope: storageScope)
     }
     
-    /// <#Description#>
+    /// Retrieve existing credentials stored in the Keychain.
     /// - Parameters:
-    ///   - username: <#username description#>
-    ///   - server: <#server description#>
-    /// - Returns: <#description#>
+    ///   - username: The username associated with the credentials.
+    ///   - server: The server associated with the credentials.
+    ///   - accessGroup: The access group associated with the credentials.
+    /// - Returns: Returns the credentials stored in the Keychain identified by the `username`, `server`, and `accessGroup`.
     public func retrieveCredentials(_ username: String, server: String? = nil, accessGroup: String? = nil) throws -> Credentials? {
         // This method uses code provided by the Apple Developer documentation at
         // https://developer.apple.com/documentation/security/keychain_services/keychain_items/searching_for_keychain_items

--- a/Sources/SecureStorage/SecureStorageError.swift
+++ b/Sources/SecureStorage/SecureStorageError.swift
@@ -16,11 +16,13 @@ public enum SecureStorageError: Error {
     case createFailed(CFError? = nil)
     case notFound
     /// The error is thrown if an entitlement is missing to use the KeyChain.
-    /// Refer to https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets
+    /// Refer to
+    /// https://developer.apple.com/documentation/security/keychain_services/keychain_items/using_the_keychain_to_manage_user_secrets
     /// about more information about the KeyChain services.
     ///
     /// If you try to use an access group to which your app doesn’t belong, the operation also fails and returns the `missingEntitlement` error.
-    /// Please refer to https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps
+    /// Please refer to
+    /// https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps
     /// for more information about KeyChain access groups.
     /// Remove the  ``CredentialsStorage`` `accessGroup` configuration value if you do not intend to use KeyChain access groups.
     case missingEntitlement

--- a/Sources/SecureStorage/SecureStorageError.swift
+++ b/Sources/SecureStorage/SecureStorageError.swift
@@ -10,7 +10,9 @@ import CryptoKit
 import Security
 
 
-enum SecureStorageError: Error {
+/// An `Error` thrown by the ``SecureStorage``.
+public enum SecureStorageError: Error {
+    /// Creation of a new element failed with a `CFError`.
     case createFailed(CFError? = nil)
     case notFound
     /// The error is thrown if an entitlement is missing to use the KeyChain.
@@ -22,6 +24,8 @@ enum SecureStorageError: Error {
     /// for more information about KeyChain access groups.
     /// Remove the  ``CredentialsStorage`` `accessGroup` configuration value if you do not intend to use KeyChain access groups.
     case missingEntitlement
+    /// The ``SecureStorage`` is unable to decode the information obtained into a credentials.
     case unexpectedCredentialsData
+    /// The ``SecureStorage`` encountered a Keychain error when interacting with the Keychain.
     case keychainError(status: OSStatus)
 }

--- a/Sources/SecureStorage/StorageScope.swift
+++ b/Sources/SecureStorage/StorageScope.swift
@@ -9,21 +9,33 @@
 import Security
 
 
-/// <#Description#>
+/// The ``StorageScope`` defines how secure data is stored by the ``SecureStorage`` component.
 public enum StorageScope: Equatable {
-    /// <#Description#>
+    /// Store the element in the Secure Enclave
     case secureEnclave(userPresence: Bool = false)
-    /// <#Description#>
+    /// Store the element in the Keychain
+    ///
+    /// The `userPresence` flag indicates if a retrieval of the item requires user presence.
+    /// https://developer.apple.com/documentation/security/keychain_services/keychain_items/restricting_keychain_item_accessibility
+    ///
+    /// The `accessGroup` defines the access group used to store the element and share it across different applications:
+    /// https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps
     case keychain(userPresence: Bool = false, accessGroup: String? = nil)
-    /// <#Description#>
+    /// Store the element in the Keychain and enable it to be synchronizable between different instances of user devices.
+    ///
+    /// The `userPresence` flag indicates if a retrieval of the item requires user presence.
+    /// https://developer.apple.com/documentation/security/keychain_services/keychain_items/restricting_keychain_item_accessibility
+    ///
+    /// The `accessGroup` defines the access group used to store the element and share it across different applications:
+    /// https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps
     case keychainSynchronizable(accessGroup: String? = nil)
     
     
-    /// <#Description#>
+    /// Store the element in the Secure Enclave
     public static let secureEnclave = secureEnclave()
-    /// <#Description#>
+    /// Store the element in the Keychain
     public static let keychain = keychain()
-    /// <#Description#>
+    /// Store the element in the Keychain and enable it to be synchronizable between different instances of user devices.
     public static let keychainSynchronizable = keychainSynchronizable()
     
     

--- a/Sources/SecureStorage/StorageScope.swift
+++ b/Sources/SecureStorage/StorageScope.swift
@@ -1,0 +1,69 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Security
+
+
+/// <#Description#>
+public enum StorageScope {
+    /// <#Description#>
+    case secureEnclave(userPresence: Bool = false)
+    /// <#Description#>
+    case keychain(userPresence: Bool = false, accessGroup: String? = nil)
+    /// <#Description#>
+    case keychainSynchronizable(userPresence: Bool = false, accessGroup: String? = nil)
+    
+    
+    /// <#Description#>
+    public static let secureEnclave = secureEnclave()
+    /// <#Description#>
+    public static let keychain = keychain()
+    /// <#Description#>
+    public static let keychainSynchronizable = keychainSynchronizable()
+    
+    
+    var userPresence: Bool {
+        switch self {
+        case let .secureEnclave(userPresence), let .keychain(userPresence, _), let .keychainSynchronizable(userPresence, _):
+            return userPresence
+        }
+    }
+    
+    var accessGroup: String? {
+        switch self {
+        case let .keychain(_, accessGroup), let .keychainSynchronizable(_, accessGroup):
+            return accessGroup
+        default:
+            return nil
+        }
+    }
+    
+    var accessControl: SecAccessControl {
+        get throws {
+            // Follows https://developer.apple.com/documentation/security/keychain_services/keychain_items/restricting_keychain_item_accessibility
+            var secAccessControlCreateFlags: SecAccessControlCreateFlags = []
+            let protection: CFTypeRef
+            if self.userPresence {
+                secAccessControlCreateFlags.insert(.userPresence)
+                protection = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            } else {
+                protection = kSecAttrAccessibleAfterFirstUnlock
+            }
+            
+            guard let access = SecAccessControlCreateWithFlags(
+                kCFAllocatorDefault,
+                protection,
+                secAccessControlCreateFlags,
+                nil
+            ) else {
+                throw SecureStorageError.createFailed()
+            }
+            return access
+        }
+    }
+}

--- a/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTests.swift
+++ b/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTests.swift
@@ -62,8 +62,8 @@ final class SecureStorageTests {
         try secureStorage.deleteKeys(forTag: "MyKey")
         try XCTAssertNil(try secureStorage.retrievePublicKey(forTag: "MyKey"))
         
-        try secureStorage.createKey("MyKey", userPresence: false)
-        try secureStorage.createKey("MyKey", userPresence: false)
+        try secureStorage.createKey("MyKey")
+        try secureStorage.createKey("MyKey")
         
         let privateKey = try XCTUnwrap(secureStorage.retrievePrivateKey(forTag: "MyKey"))
         let publicKey = try XCTUnwrap(secureStorage.retrievePublicKey(forTag: "MyKey"))

--- a/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTests.swift
+++ b/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTests.swift
@@ -41,7 +41,11 @@ final class SecureStorageTests {
         
         var serverCredentials = Credentials(username: "@PSchmiedmayer", password: "CardinalKitInventor")
         try secureStorage.store(credentials: serverCredentials, server: "twitter.com")
-        try secureStorage.store(credentials: serverCredentials, server: "twitter.com", storageScope: .keychainSynchronizable) // Overwrite existing credentials.
+        try secureStorage.store(
+            credentials: serverCredentials,
+            server: "twitter.com",
+            storageScope: .keychainSynchronizable
+        ) // Overwrite existing credentials.
         
         let retrievedCredentials = try XCTUnwrap(secureStorage.retrieveCredentials("@PSchmiedmayer", server: "twitter.com"))
         try XCTAssertEqual(serverCredentials, retrievedCredentials)

--- a/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTests.swift
+++ b/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTests.swift
@@ -18,6 +18,7 @@ final class SecureStorageTests {
         
         var serverCredentials = Credentials(username: "@PSchmiedmayer", password: "CardinalKitInventor")
         try secureStorage.store(credentials: serverCredentials)
+        try secureStorage.store(credentials: serverCredentials, storageScope: .keychainSynchronizable)
         try secureStorage.store(credentials: serverCredentials, storageScope: .keychainSynchronizable) // Overwrite existing credentials.
         
         let retrievedCredentials = try XCTUnwrap(secureStorage.retrieveCredentials("@PSchmiedmayer"))
@@ -41,11 +42,12 @@ final class SecureStorageTests {
         
         var serverCredentials = Credentials(username: "@PSchmiedmayer", password: "CardinalKitInventor")
         try secureStorage.store(credentials: serverCredentials, server: "twitter.com")
+        try secureStorage.store(credentials: serverCredentials, server: "twitter.com") // Overwrite existing credentials.
         try secureStorage.store(
             credentials: serverCredentials,
             server: "twitter.com",
             storageScope: .keychainSynchronizable
-        ) // Overwrite existing credentials.
+        )
         
         let retrievedCredentials = try XCTUnwrap(secureStorage.retrieveCredentials("@PSchmiedmayer", server: "twitter.com"))
         try XCTAssertEqual(serverCredentials, retrievedCredentials)

--- a/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTests.swift
+++ b/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTests.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+@testable import CardinalKit
 import Foundation
 import SecureStorage
 import Security
@@ -17,10 +18,11 @@ final class SecureStorageTests {
         
         var serverCredentials = Credentials(username: "@PSchmiedmayer", password: "CardinalKitInventor")
         try secureStorage.store(credentials: serverCredentials)
-        try secureStorage.store(credentials: serverCredentials) // Overwrite existing credentials.
+        try secureStorage.store(credentials: serverCredentials, storageScope: .keychainSynchronizable) // Overwrite existing credentials.
         
         let retrievedCredentials = try XCTUnwrap(secureStorage.retrieveCredentials("@PSchmiedmayer"))
         try XCTAssertEqual(serverCredentials, retrievedCredentials)
+        try XCTAssertEqual(serverCredentials.id, retrievedCredentials.id)
         
         
         serverCredentials = Credentials(username: "@CardinalKit", password: "Paul")
@@ -39,7 +41,7 @@ final class SecureStorageTests {
         
         var serverCredentials = Credentials(username: "@PSchmiedmayer", password: "CardinalKitInventor")
         try secureStorage.store(credentials: serverCredentials, server: "twitter.com")
-        try secureStorage.store(credentials: serverCredentials, server: "twitter.com") // Overwrite existing credentials.
+        try secureStorage.store(credentials: serverCredentials, server: "twitter.com", storageScope: .keychainSynchronizable) // Overwrite existing credentials.
         
         let retrievedCredentials = try XCTUnwrap(secureStorage.retrieveCredentials("@PSchmiedmayer", server: "twitter.com"))
         try XCTAssertEqual(serverCredentials, retrievedCredentials)
@@ -56,13 +58,33 @@ final class SecureStorageTests {
         try XCTAssertNil(try secureStorage.retrieveCredentials("@CardinalKit", server: "stanford.edu"))
     }
     
+    func testCredentialsNotWorkingWithSecureEnclave() throws {
+        var expecation: Int = 0
+        
+        CardinalKitAssert.injected = CardinalKitAssert(
+            assert: { condition, message, _, _  in
+                print("Precondition: \(condition()): \"\(message())\"")
+                expecation += 1
+            }
+        )
+        
+        let secureStorage = SecureStorage<UITestsAppStandard>()
+        let serverCredentials = Credentials(username: "@PSchmiedmayer", password: "CardinalKitInventor")
+        try secureStorage.store(credentials: serverCredentials, server: "twitter.com")
+        
+        try XCTAssertEqual(expecation, 1)
+        
+        CardinalKitAssert.reset()
+    }
+    
     func testKeys() throws {
         let secureStorage = SecureStorage<UITestsAppStandard>()
         
         try secureStorage.deleteKeys(forTag: "MyKey")
         try XCTAssertNil(try secureStorage.retrievePublicKey(forTag: "MyKey"))
         
-        try secureStorage.createKey("MyKey")
+        try secureStorage.createKey("MyKey", storageScope: .keychain)
+        try secureStorage.createKey("MyKey", storageScope: .keychainSynchronizable)
         try secureStorage.createKey("MyKey")
         
         let privateKey = try XCTUnwrap(secureStorage.retrievePrivateKey(forTag: "MyKey"))

--- a/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTestsView.swift
+++ b/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTestsView.swift
@@ -21,6 +21,7 @@ struct SecureStorageTestsView: View {
                 do {
                     try secureStorageTests.testCredentials()
                     try secureStorageTests.testInternetCredentials()
+                    try secureStorageTests.testCredentialsNotWorkingWithSecureEnclave()
                     try secureStorageTests.testKeys()
                     testState = "Passed"
                 } catch {

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -34,14 +34,14 @@
             BlueprintIdentifier = "CardinalKit"
             BuildableName = "CardinalKit"
             BlueprintName = "CardinalKit"
-            ReferencedContainer = "container:..">
+            ReferencedContainer = "container:../..">
          </BuildableReference>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "SecureStorage"
             BuildableName = "SecureStorage"
             BlueprintName = "SecureStorage"
-            ReferencedContainer = "container:..">
+            ReferencedContainer = "container:../..">
          </BuildableReference>
       </CodeCoverageTargets>
       <Testables>

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -27,7 +27,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -42,6 +43,13 @@
             BuildableName = "SecureStorage"
             BlueprintName = "SecureStorage"
             ReferencedContainer = "container:../..">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2F6D139128F5F384007C25D6"
+            BuildableName = "TestApp.app"
+            BlueprintName = "TestApp"
+            ReferencedContainer = "container:UITests.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
       <Testables>

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -27,8 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      codeCoverageEnabled = "YES">
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -43,13 +42,6 @@
             BuildableName = "SecureStorage"
             BlueprintName = "SecureStorage"
             ReferencedContainer = "container:../..">
-         </BuildableReference>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "2F6D139128F5F384007C25D6"
-            BuildableName = "TestApp.app"
-            BlueprintName = "TestApp"
-            ReferencedContainer = "container:UITests.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
       <Testables>

--- a/codecov.yml
+++ b/codecov.yml
@@ -30,7 +30,7 @@ coverage:
         # Choose a minimum coverage ratio that the commit must meet to be considered a success
         target: auto
         # Allow the coverage to drop by X%, and posting a success status.
-        threshold: 0%
+        threshold: 0.1%
 
 parsers:
   gcov:

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,6 @@
 
 ignore:
 - "Tests"
-- "Example"
 
 codecov:
   require_ci_to_pass: yes


### PR DESCRIPTION
# Define a SecureStorage StorageScope

## :recycle: Current situation & Problem
Each time a new key or certificate is created we need to ensure that we store it according to a specific security scope defined by the user. This granular control is currently not possible with the SecureStorage module.

## :bulb: Proposed solution
We define a `StorageScope` enum to define this scope.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

