### PR TITLE
XCTRuntimeAssertions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,13 @@ let package = Package(
                 .target(name: "XCTRuntimeAssertions")
             ]
         ),
+        .testTarget(
+            name: "CardinalKitTests",
+            dependencies: [
+                .target(name: "CardinalKit"),
+                .target(name: "XCTRuntimeAssertions")
+            ]
+        ),
         .target(
             name: "SecureStorage",
             dependencies: [
@@ -39,9 +46,8 @@ let package = Package(
             name: "XCTRuntimeAssertions"
         ),
         .testTarget(
-            name: "CardinalKitTests",
+            name: "XCTRuntimeAssertionsTests",
             dependencies: [
-                .target(name: "CardinalKit"),
                 .target(name: "XCTRuntimeAssertions")
             ]
         )

--- a/Package.swift
+++ b/Package.swift
@@ -18,29 +18,31 @@ let package = Package(
     ],
     products: [
         .library(name: "CardinalKit", targets: ["CardinalKit"]),
-        .library(name: "SecureStorage", targets: ["SecureStorage"])
+        .library(name: "SecureStorage", targets: ["SecureStorage"]),
+        .library(name: "XCTRuntimeAssertions", targets: ["XCTRuntimeAssertions"])
     ],
     targets: [
         .target(
-            name: "CardinalKit"
+            name: "CardinalKit",
+            dependencies: [
+                .target(name: "XCTRuntimeAssertions")
+            ]
         ),
         .target(
             name: "SecureStorage",
             dependencies: [
-                .target(name: "CardinalKit")
+                .target(name: "CardinalKit"),
+                .target(name: "XCTRuntimeAssertions")
             ]
         ),
         .target(
-            name: "XCTCardinalKit",
-            dependencies: [
-                .target(name: "CardinalKit")
-            ]
+            name: "XCTRuntimeAssertions"
         ),
         .testTarget(
             name: "CardinalKitTests",
             dependencies: [
                 .target(name: "CardinalKit"),
-                .target(name: "XCTCardinalKit")
+                .target(name: "XCTRuntimeAssertions")
             ]
         )
     ]

--- a/Sources/CardinalKit/CardinalKit/CardinalKit.swift
+++ b/Sources/CardinalKit/CardinalKit/CardinalKit.swift
@@ -57,6 +57,6 @@ public class CardinalKit<S: Standard>: AnyCardinalKit, ObservableObject {
         self.typedCollection = TypedCollection(logger: logger)
         
         let sortedComponents = _DependencyManager(components).sortedComponents
-        sortedComponents.configureAny(cardinalKit: self)
+        sortedComponents._configureAny(cardinalKit: self)
     }
 }

--- a/Sources/CardinalKit/Configuration/AnyComponent.swift
+++ b/Sources/CardinalKit/Configuration/AnyComponent.swift
@@ -15,14 +15,17 @@ public protocol _AnyComponent {
     /// Type-erased version of ``Component/configure(cardinalKit:)``.
     ///
     /// - Parameter cardinalKit: A type-erased ``CardinalKit`` instance.
-    func configureAny(cardinalKit: Any)
+    func _configureAny(cardinalKit: Any) // swiftlint:disable:this identifier_name
+    // We want the visit function to be hidden from autocompletion and document generation. Therefore, we use the `_` prefix.
 }
 
 
 extension Array where Element == _AnyComponent {
-    func configureAny(cardinalKit: Any) {
+    // We want the visit function to be hidden from autocompletion and document generation. Therefore, we use the `_` prefix.
+    // swiftlint:disable:next identifier_name
+    func _configureAny(cardinalKit: Any) {
         forEach {
-            $0.configureAny(cardinalKit: cardinalKit)
+            $0._configureAny(cardinalKit: cardinalKit)
         }
     }
 }

--- a/Sources/CardinalKit/Configuration/Component.swift
+++ b/Sources/CardinalKit/Configuration/Component.swift
@@ -22,8 +22,8 @@ public protocol Component: _AnyComponent, TypedCollectionKey {
 
 extension Component {
     // A documentation for this methodd exists in the `_AnyComponent` type which SwiftLint doesn't recognize.
-    // swiftlint:disable:next missing_docs
-    public func configureAny(cardinalKit: Any) {
+    // swiftlint:disable:next missing_docs identifier_name
+    public func _configureAny(cardinalKit: Any) {
         guard let typedCardinalKit = cardinalKit as? CardinalKit<ComponentStandard> else {
             return
         }

--- a/Sources/CardinalKit/Module/Capabilities/Dependencies/DependencyManager.swift
+++ b/Sources/CardinalKit/Module/Capabilities/Dependencies/DependencyManager.swift
@@ -56,11 +56,17 @@ public class _DependencyManager { // swiftlint:disable:this type_name
         
         // Detect circles in the `recursiveSearch` collection.
         guard !recursiveSearch.contains(where: { type(of: $0) == T.self }) else {
-            let dependencyChain = recursiveSearch.map { String(describing: type(of: $0)) }.joined(separator: ", ")
+            let dependencyChain = recursiveSearch
+                .map { String(describing: type(of: $0)) }
+                .joined(separator: ", ")
+            
+            // The last element must exist as we entered the statement using a successful `contains` statement.
+            // There is not chance to recover here: If there is a crash here, we would fail in the precondition statement in the next line anyways
+            let lastElement = recursiveSearch.last! // swiftlint:disable:this force_unwrapping
             preconditionFailure(
                 """
                 The `DependencyManager` has detected a depenency cycle of your CardinalKit components.
-                The current dependency chain is: \(dependencyChain). The \(String(describing: type(of: recursiveSearch.last.unsafelyUnwrapped))) required a type already present in the dependency chain.
+                The current dependency chain is: \(dependencyChain). The \(String(describing: type(of: lastElement))) required a type already present in the dependency chain.
                 
                 Please ensure that the components you use or develop can not trigger a dependency cycle.
                 """

--- a/Sources/CardinalKit/Module/Capabilities/Dependencies/DependencyManager.swift
+++ b/Sources/CardinalKit/Module/Capabilities/Dependencies/DependencyManager.swift
@@ -92,9 +92,7 @@ public class _DependencyManager { // swiftlint:disable:this type_name
         dependingComponents.removeAll(where: { $0 === dependingComponent })
         precondition(
             dependingComponentsCount - 1 == dependingComponents.count,
-            """
-            Only call `passedAllRequirements` in the `dependencyResolution(_: DependencyManager)` function of your `DependingComponent`.
-            """
+            "Only call `passedAllRequirements` in the `dependencyResolution(_: DependencyManager)` function of your `DependingComponent`."
         )
         
         sortedComponents.append(dependingComponent)

--- a/Sources/CardinalKit/Module/Capabilities/Dependencies/DependencyManager.swift
+++ b/Sources/CardinalKit/Module/Capabilities/Dependencies/DependencyManager.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+import XCTRuntimeAssertions
+
 
 /// A ``DependencyManager`` in CardinalKit is used to gather information about dependencies of a ``DependingComponent``.
 public class _DependencyManager { // swiftlint:disable:this type_name
@@ -61,8 +63,7 @@ public class _DependencyManager { // swiftlint:disable:this type_name
             // The last element must exist as we entered the statement using a successful `contains` statement.
             // There is not chance to recover here: If there is a crash here, we would fail in the precondition statement in the next line anyways
             let lastElement = recursiveSearch.last! // swiftlint:disable:this force_unwrapping
-            precondition(
-                false, // Nescessary to call our version of the `precondition` function to use this in unit testing.
+            preconditionFailure(
                 """
                 The `DependencyManager` has detected a depenency cycle of your CardinalKit components.
                 The current dependency chain is: \(dependencyChain). The \(String(describing: type(of: lastElement))) required a type already present in the dependency chain.
@@ -70,7 +71,6 @@ public class _DependencyManager { // swiftlint:disable:this type_name
                 Please ensure that the components you use or develop can not trigger a dependency cycle.
                 """
             )
-            return
         }
         
         // If there is no cycle, resolved the dependencies of the component found in the `dependingComponents`.
@@ -79,14 +79,12 @@ public class _DependencyManager { // swiftlint:disable:this type_name
     
     private func resolvedAllDependencies(_ dependingComponent: any DependingComponent) {
         guard !recursiveSearch.isEmpty else {
-            precondition(false, "Internal logic error in the `DependencyManager`")
-            return
+            preconditionFailure("Internal logic error in the `DependencyManager`")
         }
         let component = recursiveSearch.removeLast()
         
         guard component === dependingComponent else {
-            precondition(false, "Internal logic error in the `DependencyManager`")
-            return
+            preconditionFailure("Internal logic error in the `DependencyManager`")
         }
         
         

--- a/Sources/CardinalKit/Module/Capabilities/Dependencies/DependencyManager.swift
+++ b/Sources/CardinalKit/Module/Capabilities/Dependencies/DependencyManager.swift
@@ -56,17 +56,11 @@ public class _DependencyManager { // swiftlint:disable:this type_name
         
         // Detect circles in the `recursiveSearch` collection.
         guard !recursiveSearch.contains(where: { type(of: $0) == T.self }) else {
-            let dependencyChain = recursiveSearch
-                .map { String(describing: type(of: $0)) }
-                .joined(separator: ", ")
-            
-            // The last element must exist as we entered the statement using a successful `contains` statement.
-            // There is not chance to recover here: If there is a crash here, we would fail in the precondition statement in the next line anyways
-            let lastElement = recursiveSearch.last! // swiftlint:disable:this force_unwrapping
+            let dependencyChain = recursiveSearch.map { String(describing: type(of: $0)) }.joined(separator: ", ")
             preconditionFailure(
                 """
                 The `DependencyManager` has detected a depenency cycle of your CardinalKit components.
-                The current dependency chain is: \(dependencyChain). The \(String(describing: type(of: lastElement))) required a type already present in the dependency chain.
+                The current dependency chain is: \(dependencyChain). The \(String(describing: type(of: recursiveSearch.last.unsafelyUnwrapped))) required a type already present in the dependency chain.
                 
                 Please ensure that the components you use or develop can not trigger a dependency cycle.
                 """

--- a/Sources/SecureStorage/SecureStorage.swift
+++ b/Sources/SecureStorage/SecureStorage.swift
@@ -11,6 +11,7 @@ import CryptoKit
 import Foundation
 import LocalAuthentication
 import Security
+import XCTRuntimeAssertions
 
 
 /// The ``SecureStorage`` serves as a resuable ``Module`` that can be used to store store small chunks of data such as credentials and keys.

--- a/Sources/XCTRuntimeAssertions/XCTFail.swift
+++ b/Sources/XCTRuntimeAssertions/XCTFail.swift
@@ -1,0 +1,18 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+/// A custom error to document test failures of the XCTRuntimeAssertions target.
+public struct XCTFail: Error, CustomStringConvertible {
+    /// Message associated with the test failure.
+    public let message: String
+    
+    
+    public var description: String {
+        message
+    }
+}

--- a/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
@@ -51,7 +51,7 @@ public func XCTRuntimeAssertion<T>(
     if fulfillmentCount != expectedFulfillmentCount {
         throw XCTFail(
             message: """
-            Expected an fulfillment count of \(fulfillmentCount), expected \(expectedFulfillmentCount).
+            Measured an fulfillment count of \(fulfillmentCount), expected \(expectedFulfillmentCount).
             \(message()) at \(file):\(line)
             """
         )

--- a/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimeAssertion.swift
@@ -5,15 +5,66 @@
 //
 // SPDX-License-Identifier: MIT
 //
-//
-// This source file is based on the Swift open-source project: https://github.com/apple/swift/blob/main/stdlib/public/core/Assert.swift
-//
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
-// Licensed under Apache License v2.0 with Runtime Library Exception
-//
-// See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-//
+
+#if DEBUG
+/// `XCTRuntimeAssertion` allows you to test assertions of types that use the `assert` and `assertionFailure` functions of the `XCTRuntimeAssertions` target.
+/// - Parameters:
+///   - validateRuntimeAssertion: An optional closure that can be used to furhter validate the messages passed to the
+///                               `assert` and `assertionFailure` functions of the `XCTRuntimeAssertions` target.
+///   - expectedFulfillmentCount: The expected fulfillment count on how often the `assert` and `assertionFailure` functions of
+///                               the `XCTRuntimeAssertions` target are called. The defailt value is 1.
+///   - message: A message that is posted on failure.
+///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
+///   - line: The line number where the failure occurs. The default is the line number where you call this function.
+///   - expression: The expression that is evaluated.
+/// - Throws: Throws an `XCTFail` error if the expection does not trigger a runtime assertion with the parameters defined above.
+/// - Returns: The value of the function if it did not throw an error as it did not trigger a runtime assertion with the parameters defined above.
+public func XCTRuntimeAssertion<T>(
+    validateRuntimeAssertion: ((String) -> Void)? = nil,
+    expectedFulfillmentCount: Int = 1,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ expression: @escaping () throws -> T
+) throws -> T {
+    var fulfillmentCount: Int = 0
+    
+    XCTRuntimeAssertionInjector.injected = XCTRuntimeAssertionInjector(
+        assert: { condition, message, _, _  in
+            if condition() {
+                let message = message() // We execute the message closure independent of the availability of the `validateRuntimeAssertion` closure.
+                validateRuntimeAssertion?(message)
+                fulfillmentCount += 1
+            }
+        }
+    )
+    
+    var result: Result<T, Error>
+    do {
+        result = .success(try expression())
+    } catch {
+        result = .failure(error)
+    }
+    
+    XCTRuntimeAssertionInjector.reset()
+    
+    if fulfillmentCount != expectedFulfillmentCount {
+        throw XCTFail(
+            message: """
+            Expected an fulfillment count of \(fulfillmentCount), expected \(expectedFulfillmentCount).
+            \(message()) at \(file):\(line)
+            """
+        )
+    }
+    
+    switch result {
+    case let .success(returnValue):
+        return returnValue
+    case let .failure(error):
+        throw error
+    }
+}
+
 
 /// Performs a traditional C-style assert with an optional message.
 ///
@@ -48,43 +99,7 @@ public func assert(
     file: StaticString = #file,
     line: UInt = #line
 ) {
-    CardinalKitAssert.injected.assert(condition, message, file, line)
-}
-
-/// Checks a necessary condition for making forward progress.
-///
-/// Use this function to detect conditions that must prevent the program from
-/// proceeding, even in shipping code.
-///
-/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
-///   configuration): If `condition` evaluates to `false`, stop program
-///   execution in a debuggable state after printing `message`.
-///
-/// * In `-O` builds (the default for Xcode's Release configuration): If
-///   `condition` evaluates to `false`, stop program execution.
-///
-/// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
-///   may assume that it *always* evaluates to `true`. Failure to satisfy that
-///   assumption is a serious programming error.
-///
-/// - Parameters:
-///   - condition: The condition to test. `condition` is not evaluated in
-///     `-Ounchecked` builds.
-///   - message: A string to print if `condition` is evaluated to `false` in a
-///     playground or `-Onone` build. The default is an empty string.
-///   - file: The file name to print with `message` if the precondition fails.
-///     The default is the file where `precondition(_:_:file:line:)` is
-///     called.
-///   - line: The line number to print along with `message` if the assertion
-///     fails. The default is the line number where
-///     `precondition(_:_:file:line:)` is called.
-public func precondition(
-    _ condition: @autoclosure () -> Bool,
-    _ message: @autoclosure () -> String = String(),
-    file: StaticString = #file,
-    line: UInt = #line
-) {
-    CardinalKitAssert.injected.precondition(condition, message, file, line)
+    XCTRuntimeAssertionInjector.injected.assert(condition, message, file, line)
 }
 
 /// Indicates that an internal sanity check failed.
@@ -113,5 +128,6 @@ public func assertionFailure(
     file: StaticString = #file,
     line: UInt = #line
 ) {
-    CardinalKitAssert.injected.assert({ false }, message, file, line)
+    XCTRuntimeAssertionInjector.injected.assert({ true }, message, file, line)
 }
+#endif

--- a/Sources/XCTRuntimeAssertions/XCTRuntimeAssertionInjector.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimeAssertionInjector.swift
@@ -6,8 +6,9 @@
 // SPDX-License-Identifier: MIT
 //
 
-class CardinalKitAssert {
-    static var injected = CardinalKitAssert()
+#if DEBUG
+class XCTRuntimeAssertionInjector {
+    static var injected = XCTRuntimeAssertionInjector()
     
     
     let assert: (() -> Bool, () -> String, StaticString, UInt) -> Void
@@ -24,6 +25,7 @@ class CardinalKitAssert {
     
     
     static func reset() {
-        injected = CardinalKitAssert()
+        injected = XCTRuntimeAssertionInjector()
     }
 }
+#endif

--- a/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
@@ -64,15 +64,7 @@ public func XCTRuntimePrecondition<T>(
         throw XCTFail(
             message: """
             The precondition was called multiple times.
-            \(message()) at \(file):\(line)
-            """
-        )
-    }
-    
-    if let result {
-        throw XCTFail(
-            message: """
-            The expression passed to XCTRuntimeAssertion returned a valid value: \(result)
+            The expression passed to XCTRuntimeAssertion returned the following value: \(String(describing: result))
             \(message()) at \(file):\(line)
             """
         )

--- a/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
@@ -56,15 +56,11 @@ public func XCTRuntimePrecondition<T>(
     // We don't use:
     // `wait(for: [expectation], timeout: timeout)`
     // here as we need to make the method independent of XCTestCase to also use it in our TestApp UITest target which fails if you import XCTest.
-    switch expressionWorkItem.wait(timeout: DispatchTime(uptimeNanoseconds: UInt64(1_000_000 * timeout))) {
-    case .success:
-        break
-    case .timedOut:
-        expressionWorkItem.cancel()
-    }
+    usleep(useconds_t(1_000_000 * timeout))
+    expressionWorkItem.cancel()
     dispatchQueue.suspend()
     
-    if fulfillmentCount != 0 {
+    if fulfillmentCount != 1 {
         throw XCTFail(
             message: """
             The precondition was called multiple times.

--- a/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
+++ b/Sources/XCTRuntimeAssertions/XCTRuntimePrecondition.swift
@@ -1,0 +1,166 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+#if DEBUG
+import Foundation
+
+
+/// `XCTRuntimePrecondition` allows you to test assertions of types that use the `precondition` and `preconditionFailure` functions of the `XCTRuntimeAssertions` target.
+/// - Parameters:
+///   - validateRuntimeAssertion: An optional closure that can be used to furhter validate the messages passed to the
+///                               `precondition` and `preconditionFailure` functions of the `XCTRuntimeAssertions` target.
+///   - timeout: A timeout defining how long to wait for the precondition to be triggered.
+///   - message: A message that is posted on failure.
+///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
+///   - line: The line number where the failure occurs. The default is the line number where you call this function.
+///   - expression: The expression that is evaluated.
+/// - Throws: Throws an `XCTFail` error if the expection does not trigger a runtime assertion with the parameters defined above.
+public func XCTRuntimePrecondition<T>(
+    validateRuntimeAssertion: ((String) -> Void)? = nil,
+    timeout: Double = 0.01,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ expression: @escaping () throws -> T
+) throws {
+    var fulfillmentCount: Int = 0
+    
+    XCTRuntimeAssertionInjector.injected = XCTRuntimeAssertionInjector(
+        precondition: { condition, message, _, _  in
+            if condition() {
+                let message = message() // We execute the message closure independent of the availability of the `validateRuntimeAssertion` closure.
+                validateRuntimeAssertion?(message)
+                fulfillmentCount += 1
+                neverReturn()
+            }
+        }
+    )
+    
+    var result: Result<T, Error>?
+    // We have to run the operation on a `DispatchQueue` as we have to call `RunLoop.current.run()` in the `preconditionFailure` call.
+    let dispatchQueue = DispatchQueue.global(qos: .userInitiated)
+    let expressionWorkItem = DispatchWorkItem {
+        do {
+            result = .success(try expression())
+        } catch {
+            result = .failure(error)
+        }
+    }
+    dispatchQueue.async(execute: expressionWorkItem)
+    
+    // We don't use:
+    // `wait(for: [expectation], timeout: timeout)`
+    // here as we need to make the method independent of XCTestCase to also use it in our TestApp UITest target which fails if you import XCTest.
+    switch expressionWorkItem.wait(timeout: DispatchTime(uptimeNanoseconds: UInt64(1_000_000 * timeout))) {
+    case .success:
+        break
+    case .timedOut:
+        expressionWorkItem.cancel()
+    }
+    dispatchQueue.suspend()
+    
+    if fulfillmentCount != 0 {
+        throw XCTFail(
+            message: """
+            The precondition was called multiple times.
+            \(message()) at \(file):\(line)
+            """
+        )
+    }
+    
+    if let result {
+        throw XCTFail(
+            message: """
+            The expression passed to XCTRuntimeAssertion returned a valid value: \(result)
+            \(message()) at \(file):\(line)
+            """
+        )
+    }
+    
+    XCTRuntimeAssertionInjector.reset()
+}
+
+private func neverReturn() -> Never {
+    // This is unfortunate but as far as I can see the only feasable way to return Never without calling a runtime crashing function, e.g. `fatalError()`.
+    repeat {
+        RunLoop.current.run()
+    } while (true)
+}
+
+/// Checks a necessary condition for making forward progress.
+///
+/// Use this function to detect conditions that must prevent the program from
+/// proceeding, even in shipping code.
+///
+/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+///   configuration): If `condition` evaluates to `false`, stop program
+///   execution in a debuggable state after printing `message`.
+///
+/// * In `-O` builds (the default for Xcode's Release configuration): If
+///   `condition` evaluates to `false`, stop program execution.
+///
+/// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
+///   may assume that it *always* evaluates to `true`. Failure to satisfy that
+///   assumption is a serious programming error.
+///
+/// - Parameters:
+///   - condition: The condition to test. `condition` is not evaluated in
+///     `-Ounchecked` builds.
+///   - message: A string to print if `condition` is evaluated to `false` in a
+///     playground or `-Onone` build. The default is an empty string.
+///   - file: The file name to print with `message` if the precondition fails.
+///     The default is the file where `precondition(_:_:file:line:)` is
+///     called.
+///   - line: The line number to print along with `message` if the assertion
+///     fails. The default is the line number where
+///     `precondition(_:_:file:line:)` is called.
+public func precondition(
+    _ condition: @autoclosure () -> Bool,
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    XCTRuntimeAssertionInjector.injected.precondition(condition, message, file, line)
+}
+
+/// Indicates that a precondition was violated.
+///
+/// Use this function to stop the program when control flow can only reach the
+/// call if your API was improperly used and execution flow is not expected to
+/// reach the call---for example, in the `default` case of a `switch` where
+/// you have knowledge that one of the other cases must be satisfied.
+///
+/// This function's effect varies depending on the build flag used:
+///
+/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+///   configuration), stops program execution in a debuggable state after
+///   printing `message`.
+///
+/// * In `-O` builds (the default for Xcode's Release configuration), stops
+///   program execution.
+///
+/// * In `-Ounchecked` builds, the optimizer may assume that this function is
+///   never called. Failure to satisfy that assumption is a serious
+///   programming error.
+///
+/// - Parameters:
+///   - message: A string to print in a playground or `-Onone` build. The
+///     default is an empty string.
+///   - file: The file name to print with `message`. The default is the file
+///     where `preconditionFailure(_:file:line:)` is called.
+///   - line: The line number to print along with `message`. The default is the
+///     line number where `preconditionFailure(_:file:line:)` is called.
+public func preconditionFailure(
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #file,
+    line: UInt = #line
+) -> Never {
+    XCTRuntimeAssertionInjector.injected.precondition({ true }, message, file, line)
+    neverReturn()
+}
+#endif

--- a/Tests/CardinalKitTests/CapabilityTests/DependencyTests/DependencyBuilderTests.swift
+++ b/Tests/CardinalKitTests/CapabilityTests/DependencyTests/DependencyBuilderTests.swift
@@ -7,7 +7,8 @@
 //
 
 import CardinalKit
-import XCTCardinalKit
+import XCTest
+import XCTRuntimeAssertions
 
 
 private class TestComponent1<ComponentStandard: Standard>: Component {}

--- a/Tests/CardinalKitTests/CapabilityTests/DependencyTests/DependencyTests.swift
+++ b/Tests/CardinalKitTests/CapabilityTests/DependencyTests/DependencyTests.swift
@@ -8,7 +8,8 @@
 
 @testable import CardinalKit
 import SwiftUI
-import XCTCardinalKit
+import XCTest
+import XCTRuntimeAssertions
 
 
 private struct TestStandard: Standard {}
@@ -167,25 +168,12 @@ final class DependencyTests: XCTestCase {
     }
     
     func testComponentCycle() throws {
-        let expectation = XCTestExpectation(description: "Precondition is called")
-        expectation.expectedFulfillmentCount = 3
-        expectation.assertForOverFulfill = true
-        
-        CardinalKitAssert.injected = CardinalKitAssert(
-            precondition: { condition, message, _, _  in
-                print("Precondition: \(condition()): \"\(message())\"")
-                expectation.fulfill()
-            }
-        )
-        
         let components: [_AnyComponent] = [
             TestComponentCircle1<MockStandard>()
         ]
         
-        _ = _DependencyManager(components).sortedComponents
-        
-        wait(for: [expectation])
-        
-        CardinalKitAssert.reset()
+        try XCTRuntimePrecondition {
+            _ = _DependencyManager(components).sortedComponents
+        }
     }
 }

--- a/Tests/CardinalKitTests/CapabilityTests/LifecycleTests/LifecycleTests.swift
+++ b/Tests/CardinalKitTests/CapabilityTests/LifecycleTests/LifecycleTests.swift
@@ -7,7 +7,8 @@
 //
 
 @testable import CardinalKit
-import XCTCardinalKit
+import XCTest
+import XCTRuntimeAssertions
 
 
 private class TestLifecycleHandler: Component, LifecycleHandler, TypedCollectionKey {

--- a/Tests/CardinalKitTests/CapabilityTests/ObservableObjectTests/ObservableObjectTests.swift
+++ b/Tests/CardinalKitTests/CapabilityTests/ObservableObjectTests/ObservableObjectTests.swift
@@ -8,7 +8,8 @@
 
 @testable import CardinalKit
 import SwiftUI
-import XCTCardinalKit
+import XCTest
+import XCTRuntimeAssertions
 
 
 final class ObservableObjectTests: XCTestCase {

--- a/Tests/CardinalKitTests/ConfigurationTests/ConfigurationBuilderTests.swift
+++ b/Tests/CardinalKitTests/ConfigurationTests/ConfigurationBuilderTests.swift
@@ -7,7 +7,8 @@
 //
 
 @testable import CardinalKit
-import XCTCardinalKit
+import XCTest
+import XCTRuntimeAssertions
 
 
 final class ComponentBuilderTests: XCTestCase {

--- a/Tests/CardinalKitTests/ConfigurationTests/ConfigurationTests.swift
+++ b/Tests/CardinalKitTests/ConfigurationTests/ConfigurationTests.swift
@@ -8,7 +8,8 @@
 
 @testable import CardinalKit
 import SwiftUI
-import XCTCardinalKit
+import XCTest
+import XCTRuntimeAssertions
 
 
 final class ComponentTests: XCTestCase {

--- a/Tests/CardinalKitTests/Shared/MockStandard.swift
+++ b/Tests/CardinalKitTests/Shared/MockStandard.swift
@@ -6,9 +6,11 @@
 // SPDX-License-Identifier: MIT
 //
 
+#if DEBUG
 import CardinalKit
 
 
 public struct MockStandard: Standard {
     public init() {}
 }
+#endif

--- a/Tests/CardinalKitTests/Shared/TestApplicationDelegate.swift
+++ b/Tests/CardinalKitTests/Shared/TestApplicationDelegate.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+#if DEBUG
 import CardinalKit
 import SwiftUI
 @_exported import XCTest
@@ -27,3 +28,4 @@ public class TestApplicationDelegate: CardinalKitAppDelegate {
         super.init()
     }
 }
+#endif

--- a/Tests/CardinalKitTests/Shared/TestConfiguration.swift
+++ b/Tests/CardinalKitTests/Shared/TestConfiguration.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+#if DEBUG
 import CardinalKit
 import SwiftUI
 @_exported import XCTest
@@ -25,3 +26,4 @@ public class TestComponent<ComponentStandard: Standard>: ObservableObject, Compo
         expectation.fulfill()
     }
 }
+#endif

--- a/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTests.swift
+++ b/Tests/UITests/TestApp/SecureStorageTests/SecureStorageTests.swift
@@ -10,6 +10,7 @@
 import Foundation
 import SecureStorage
 import Security
+import XCTRuntimeAssertions
 
 
 final class SecureStorageTests {
@@ -65,22 +66,12 @@ final class SecureStorageTests {
     }
     
     func testCredentialsNotWorkingWithSecureEnclave() throws {
-        var expecation: Int = 0
-        
-        CardinalKitAssert.injected = CardinalKitAssert(
-            assert: { condition, message, _, _  in
-                print("Precondition: \(condition()): \"\(message())\"")
-                expecation += 1
-            }
-        )
-        
         let secureStorage = SecureStorage<UITestsAppStandard>()
         let serverCredentials = Credentials(username: "@PSchmiedmayer", password: "CardinalKitInventor")
-        try secureStorage.store(credentials: serverCredentials, server: "twitter.com")
-        
-        try XCTAssertEqual(expecation, 1)
-        
-        CardinalKitAssert.reset()
+
+        try XCTRuntimeAssertion {
+            try secureStorage.store(credentials: serverCredentials, server: "twitter.com")
+        }
     }
     
     func testKeys() throws {

--- a/Tests/UITests/TestAppUITests/ObservableObjectComponentTests.swift
+++ b/Tests/UITests/TestAppUITests/ObservableObjectComponentTests.swift
@@ -24,6 +24,6 @@ final class ObservableObjectComponentTests: XCTestCase {
         app.tabBars["Tab Bar"].buttons["ObservableObjectTests"].tap()
         
         XCTAssertTrue(app.images["Globe"].exists)
-        XCTAssertTrue(app.staticTexts["Hello, Paul!"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["Hello, Paul!"].waitForExistence(timeout: 0.1))
     }
 }

--- a/Tests/UITests/TestAppUITests/SecureStorageTests.swift
+++ b/Tests/UITests/TestAppUITests/SecureStorageTests.swift
@@ -23,6 +23,6 @@ final class SecureStorageTests: XCTestCase {
         
         app.tabBars["Tab Bar"].buttons["SecureStorageTests"].tap()
         
-        XCTAssertTrue(app.staticTexts["Passed"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["Passed"].waitForExistence(timeout: 0.2))
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F6051CC290C5BDC0003D458 /* XCTRuntimeAssertions in Frameworks */ = {isa = PBXBuildFile; productRef = 2F6051CB290C5BDC0003D458 /* XCTRuntimeAssertions */; };
+		2F67A5BA290C69640092CAD6 /* SecureStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 2F67A5B9290C69640092CAD6 /* SecureStorage */; };
 		2F6D139828F5F384007C25D6 /* ObservableObjectTestsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6D139728F5F384007C25D6 /* ObservableObjectTestsView.swift */; };
 		2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F6D139928F5F386007C25D6 /* Assets.xcassets */; };
 		2F9F07E2290906A200CDC598 /* SecureStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9F07E1290906A200CDC598 /* SecureStorageTests.swift */; };
@@ -19,7 +21,6 @@
 		2F9F07F529090BA900CDC598 /* ObservableObjectComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9F07F429090BA900CDC598 /* ObservableObjectComponentTests.swift */; };
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
 		2FC42FD9290ADD8800B08F18 /* CardinalKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2FC42FD8290ADD8800B08F18 /* CardinalKit */; };
-		2FC42FDB290ADD8800B08F18 /* SecureStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 2FC42FDA290ADD8800B08F18 /* SecureStorage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,8 +55,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2F67A5BA290C69640092CAD6 /* SecureStorage in Frameworks */,
 				2FC42FD9290ADD8800B08F18 /* CardinalKit in Frameworks */,
-				2FC42FDB290ADD8800B08F18 /* SecureStorage in Frameworks */,
+				2F6051CC290C5BDC0003D458 /* XCTRuntimeAssertions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -163,7 +165,8 @@
 			name = TestApp;
 			packageProductDependencies = (
 				2FC42FD8290ADD8800B08F18 /* CardinalKit */,
-				2FC42FDA290ADD8800B08F18 /* SecureStorage */,
+				2F6051CB290C5BDC0003D458 /* XCTRuntimeAssertions */,
+				2F67A5B9290C69640092CAD6 /* SecureStorage */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -403,6 +406,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -432,6 +436,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -522,13 +527,17 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2F6051CB290C5BDC0003D458 /* XCTRuntimeAssertions */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XCTRuntimeAssertions;
+		};
+		2F67A5B9290C69640092CAD6 /* SecureStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SecureStorage;
+		};
 		2FC42FD8290ADD8800B08F18 /* CardinalKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = CardinalKit;
-		};
-		2FC42FDA290ADD8800B08F18 /* SecureStorage */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SecureStorage;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -43,6 +43,13 @@
             BlueprintName = "SecureStorage"
             ReferencedContainer = "container:../..">
          </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "XCTRuntimeAssertions"
+            BuildableName = "XCTRuntimeAssertions"
+            BlueprintName = "XCTRuntimeAssertions"
+            ReferencedContainer = "container:../..">
+         </BuildableReference>
       </CodeCoverageTargets>
       <Testables>
          <TestableReference

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
@@ -50,7 +50,6 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
             validateRuntimeAssertion: {
                 XCTAssertEqual("preconditionFailure()", $0)
             },
-            timeout: 0.02,
             "testXCTRuntimePrecondition"
         ) {
             precondition(number == 42, "preconditionFailure()")

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
@@ -60,7 +60,7 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
         
         do {
             let result = try XCTRuntimeAssertion {
-                return "Hello Paul 👋"
+                "Hello Paul 👋"
             }
             XCTAssertEqual(result, "Hello Paul 👋")
         } catch let error as XCTFail {
@@ -109,7 +109,7 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
         
         do {
             try XCTRuntimePrecondition {
-                return "Hello Paul 👋"
+                "Hello Paul 👋"
             }
         } catch let error as XCTFail {
             XCTAssertTrue(error.message.contains("Hello Paul 👋"))

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
@@ -109,7 +109,7 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
         
         do {
             try XCTRuntimePrecondition {
-                "Hello Paul 👋"
+                print("Hello Paul 👋")
             }
         } catch let error as XCTFail {
             XCTAssertTrue(error.message.contains("The precondition was called multiple times."))

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
@@ -64,7 +64,6 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
             }
             XCTAssertEqual(result, "Hello Paul 👋")
         } catch let error as XCTFail {
-            print("LOG: \(error.message)")
             XCTAssertTrue(error.message.contains("Measured an fulfillment count of 0, expected 1."))
         }
         
@@ -73,7 +72,6 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
                 throw XCTRuntimeAssertionNotTriggeredError()
             }
         } catch let error as XCTFail {
-            print("LOG: \(error.description)")
             XCTAssertTrue(error.description.contains("Measured an fulfillment count of 0, expected 1."))
         }
     }
@@ -114,8 +112,7 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
                 "Hello Paul 👋"
             }
         } catch let error as XCTFail {
-            print("LOG: \(error.message)")
-            XCTAssertTrue(error.message.contains("Hello Paul 👋"))
+            XCTAssertTrue(error.message.contains("The precondition was called multiple times."))
         }
         
         do {
@@ -123,8 +120,7 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
                 throw XCTRuntimePreconditionNotTriggeredError()
             }
         } catch let error as XCTFail {
-            print("LOG: \(error.description)")
-            XCTAssertTrue(error.description.contains("XCTRuntimePreconditionNotTriggeredError"))
+            XCTAssertTrue(error.description.contains("The precondition was called multiple times."))
         }
     }
 }

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
@@ -64,6 +64,7 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
             }
             XCTAssertEqual(result, "Hello Paul 👋")
         } catch let error as XCTFail {
+            print("LOG: \(error.message)")
             XCTAssertTrue(error.message.contains("Measured an fulfillment count of 0, expected 1."))
         }
         
@@ -72,7 +73,8 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
                 throw XCTRuntimeAssertionNotTriggeredError()
             }
         } catch let error as XCTFail {
-            XCTAssertTrue(error.message.contains("Measured an fulfillment count of 0, expected 1."))
+            print("LOG: \(error.description)")
+            XCTAssertTrue(error.description.contains("Measured an fulfillment count of 0, expected 1."))
         }
     }
     
@@ -112,6 +114,7 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
                 "Hello Paul 👋"
             }
         } catch let error as XCTFail {
+            print("LOG: \(error.message)")
             XCTAssertTrue(error.message.contains("Hello Paul 👋"))
         }
         
@@ -120,6 +123,7 @@ final class XCTRuntimeAssertionsTests: XCTestCase {
                 throw XCTRuntimePreconditionNotTriggeredError()
             }
         } catch let error as XCTFail {
+            print("LOG: \(error.description)")
             XCTAssertTrue(error.description.contains("XCTRuntimePreconditionNotTriggeredError"))
         }
     }

--- a/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
+++ b/Tests/XCTRuntimeAssertionsTests/XCTRuntimeAssertionsTests.swift
@@ -1,0 +1,67 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+@testable import XCTRuntimeAssertions
+
+
+final class XCTRuntimeAssertionsTests: XCTestCase {
+    func testXCTRuntimeAssertion() throws {
+        let messages = [
+            "assertionFailure()",
+            "assert(false)",
+            "assert(42 == 42)"
+        ]
+        var collectedMessages: [String] = []
+        let number = 42
+        
+        try XCTRuntimeAssertion(
+            validateRuntimeAssertion: {
+                collectedMessages.append($0)
+            },
+            expectedFulfillmentCount: 3,
+            "testXCTRuntimeAssertion"
+        ) {
+            assertionFailure(messages[0])
+            assert(true, messages[1])
+            assert(number == 42, messages[2])
+        }
+        
+        XCTAssertEqual(messages, collectedMessages)
+        
+        try XCTRuntimeAssertion(validateRuntimeAssertion: { XCTAssertEqual($0, "") }) {
+            assertionFailure()
+        }
+        
+        try XCTRuntimeAssertion {
+            assertionFailure()
+        }
+    }
+    
+    func testXCTRuntimePrecondition() throws {
+        let number = 42
+        
+        try XCTRuntimePrecondition(
+            validateRuntimeAssertion: {
+                XCTAssertEqual("preconditionFailure()", $0)
+            },
+            timeout: 0.02,
+            "testXCTRuntimePrecondition"
+        ) {
+            precondition(number == 42, "preconditionFailure()")
+        }
+        
+        try XCTRuntimePrecondition(validateRuntimeAssertion: { XCTAssertEqual($0, "") }) {
+            preconditionFailure()
+        }
+        
+        try XCTRuntimePrecondition {
+            preconditionFailure()
+        }
+    }
+}


### PR DESCRIPTION
# Introduces an XCTRuntimeAssertions

## :recycle: Current situation & Problem
Currently testing preconditions and assertions in targets is not supported by Apple's XCTest.

## :bulb: Proposed solution
The XCTRuntimeAssertions allows developers to test preconditions and assertions in unit test and our UI tests test application.

## :gear: Release Notes 
Introduces two test methods:
- Test assertions: `XCTRuntimeAssertion<T>(
    validateRuntimeAssertion: ((String) -> Void)? = nil,
    expectedFulfillmentCount: Int = 1,
    _ message: @autoclosure () -> String = "",
    file: StaticString = #filePath,
    line: UInt = #line,
    _ expression: @escaping () throws -> T
) throws -> T`
- Test preconditions: `XCTRuntimePrecondition<T>(
    validateRuntimeAssertion: ((String) -> Void)? = nil,
    timeout: Double = 0.01,
    _ message: @autoclosure () -> String = "",
    file: StaticString = #filePath,
    line: UInt = #line,
    _ expression: @escaping () throws -> T
) throws`

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

