### PR TITLE
The Standard Actor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     ],
     products: [
         .library(name: "CardinalKit", targets: ["CardinalKit"]),
-        .library(name: "SecureStorage", targets: ["SecureStorage"]),
         .library(name: "LocalStorage", targets: ["LocalStorage"]),
+        .library(name: "SecureStorage", targets: ["SecureStorage"]),
         .library(name: "XCTRuntimeAssertions", targets: ["XCTRuntimeAssertions"])
     ],
     targets: [

--- a/Sources/CardinalKit/CardinalKit/CardinalKit.swift
+++ b/Sources/CardinalKit/CardinalKit/CardinalKit.swift
@@ -32,7 +32,7 @@ import SwiftUI
 ///     }
 /// }
 /// ```
-public class CardinalKit<S: Standard>: AnyCardinalKit, ObservableObject {
+public actor CardinalKit<S: Standard>: AnyCardinalKit, ObservableObject {
     /// A typesafe typedCollection of different elements of an ``CardinalKit/CardinalKit`` instance.
     public let typedCollection: TypedCollection
     /// Logger used to log events in the ``CardinalKit/CardinalKit`` instance.
@@ -50,9 +50,15 @@ public class CardinalKit<S: Standard>: AnyCardinalKit, ObservableObject {
         self.typedCollection = TypedCollection(logger: logger)
         self.standard = standard
         
-        let sortedComponents = DependencyManager(components).sortedComponents
+        var componentsAndStandard = components
+        componentsAndStandard.append(standard)
+        
+        let sortedComponents = DependencyManager(componentsAndStandard).sortedComponents
+        
         for component in sortedComponents {
-            component.configure(cardinalKit: self)
+            component.inject(standard: standard)
+            component.configure()
+            component.saveInTypedCollection(cardinalKit: self)
         }
     }
 }

--- a/Sources/CardinalKit/CardinalKit/CardinalKitAppDelegate.swift
+++ b/Sources/CardinalKit/CardinalKit/CardinalKitAppDelegate.swift
@@ -32,7 +32,7 @@ import SwiftUI
 /// }
 /// ```
 open class CardinalKitAppDelegate: NSObject, UIApplicationDelegate {
-    private struct DefaultStandard: Standard {}
+    private actor DefaultStandard: Standard {}
     
     
     private(set) lazy var cardinalKit: AnyCardinalKit = configuration.cardinalKit

--- a/Sources/CardinalKit/Configuration/Component.swift
+++ b/Sources/CardinalKit/Configuration/Component.swift
@@ -12,19 +12,19 @@ public protocol Component<ComponentStandard>: AnyObject, TypedCollectionKey {
     /// A ``Component/ComponentStandard`` defines what ``Standard`` the component supports.
     associatedtype ComponentStandard: Standard
     
-    /// The ``Component/configure(cardinalKit:)`` method is called on the initialization of the CardinalKit instance to perform a lightweight configuration of the component.
+    /// The ``Component/configure()`` method is called on the initialization of the CardinalKit instance to perform a lightweight configuration of the component.
     ///
-    /// If a ``Component`` needs to store a reference to the ``CardinalKit`` instance, it should keep a **weak** reference to the ``CardinalKit`` instance.
     /// It is advised that longer setup tasks are done in an asynchronous task and started during the call of the configure method.
-    /// - Parameter cardinalKit: The ``CardinalKit`` instance used in the instance of a CardinalKit project.
-    func configure(cardinalKit: CardinalKit<ComponentStandard>)
+    func configure()
 }
 
 
 extension Component {
-    // A documentation for this methodd exists in the `Component` type which SwiftLint doesn't recognize.
-    // swiftlint:disable:next missing_docs
-    public func configure(cardinalKit: CardinalKit<ComponentStandard>) {
+    func saveInTypedCollection(cardinalKit: CardinalKit<ComponentStandard>) {
         cardinalKit.typedCollection.set(Self.self, to: self as? Self.Value)
     }
+    
+    // A documentation for this methodd exists in the `Component` type which SwiftLint doesn't recognize.
+    // swiftlint:disable:next missing_docs
+    public func configure() {}
 }

--- a/Sources/CardinalKit/Module/Capabilities/Dependencies/Component+Dependencies.swift
+++ b/Sources/CardinalKit/Module/Capabilities/Dependencies/Component+Dependencies.swift
@@ -40,7 +40,7 @@ extension Component {
     /// }
     /// ```
     ///
-    /// You can access the wrapped value of the ``Dependency`` after the ``Component`` is configured using ``Component/configure(cardinalKit:)-38pyu``,
-    /// e.g. in the ``LifecycleHandler/willFinishLaunchingWithOptions(_:launchOptions:)-lsab`` function.
+    /// You can access the wrapped value of the ``Dependency`` after the ``Component`` is configured using ``Component/configure()``,
+    /// e.g. in the ``LifecycleHandler/willFinishLaunchingWithOptions(_:launchOptions:)`` function.
     public typealias Dependency<C: Component> = _DependencyPropertyWrapper<C, ComponentStandard> where C.ComponentStandard == ComponentStandard
 }

--- a/Sources/CardinalKit/Standard/Component+Standard.swift
+++ b/Sources/CardinalKit/Standard/Component+Standard.swift
@@ -22,16 +22,16 @@ extension Component {
 extension Component {
     /// Defines access to the shared ``Standard`` actor.
     ///
-    /// A ``Component`` can define the injection of a ``Standard`` using the ``@SharedStandard`` property wrapper:
+    /// A ``Component`` can define the injection of a ``Standard`` using the ``@StandardActor`` property wrapper:
     /// ```
     /// class ExampleComponent: Component {
     ///     typealias ComponentStandard = ExampleStandard
     ///
-    ///     @SharedStandard var standard: ExampleStandard
+    ///     @StandardActor var standard: ExampleStandard
     /// }
     /// ```
     ///
     /// You can access the wrapped value of the ``Standard`` after the ``Component`` is configured using ``Component/configure()``,
     /// e.g. in the ``LifecycleHandler/willFinishLaunchingWithOptions(_:launchOptions:)`` function.
-    public typealias SharedStandard = _StandardPropertyWrapper<ComponentStandard>
+    public typealias StandardActor = _StandardPropertyWrapper<ComponentStandard>
 }

--- a/Sources/CardinalKit/Standard/Component+Standard.swift
+++ b/Sources/CardinalKit/Standard/Component+Standard.swift
@@ -1,0 +1,37 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+extension Component {
+    func inject(standard: ComponentStandard) {
+        let mirror = Mirror(reflecting: self)
+        for child in mirror.children {
+            guard let standardPropertyWrapper = child.value as? _StandardPropertyWrapper<ComponentStandard> else {
+                continue
+            }
+            standardPropertyWrapper.inject(standard: standard)
+        }
+    }
+}
+
+
+extension Component {
+    /// Defines access to the shared ``Standard`` actor.
+    ///
+    /// A ``Component`` can define the injection of a ``Standard`` using the ``@SharedStandard`` property wrapper:
+    /// ```
+    /// class ExampleComponent: Component {
+    ///     typealias ComponentStandard = ExampleStandard
+    ///
+    ///     @SharedStandard var standard: ExampleStandard
+    /// }
+    /// ```
+    ///
+    /// You can access the wrapped value of the ``Standard`` after the ``Component`` is configured using ``Component/configure()``,
+    /// e.g. in the ``LifecycleHandler/willFinishLaunchingWithOptions(_:launchOptions:)`` function.
+    public typealias SharedStandard = _StandardPropertyWrapper<ComponentStandard>
+}

--- a/Sources/CardinalKit/Standard/Standard.swift
+++ b/Sources/CardinalKit/Standard/Standard.swift
@@ -10,4 +10,4 @@ import Foundation
 
 
 /// A ``Standard`` defines a common representation of resources using by different `CardinalKit` components.
-public protocol Standard {}
+public protocol Standard: Actor, Component where ComponentStandard == Self { }

--- a/Sources/CardinalKit/Standard/StandardPropertyWrapper.swift
+++ b/Sources/CardinalKit/Standard/StandardPropertyWrapper.swift
@@ -1,0 +1,43 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTRuntimeAssertions
+
+
+/// Refer to ``Component/SharedStandard`` for information on how to use the `@SharedStandard` property wrapper. Do not use the `_StandardPropertyWrapper` directly.
+@propertyWrapper
+public class _StandardPropertyWrapper<S: Standard> {
+    // swiftlint:disable:previous type_name
+    // We want the _StandardPropertyWrapper type to be hidden from autocompletion and document generation.
+    
+    
+    var standard: S?
+    
+    
+    /// The injected ``Standard`` that is resolved by ``CardinalKit``
+    public var wrappedValue: S {
+        guard let standard else {
+            preconditionFailure(
+                """
+                A `_StandardPropertyWrapper`'s wrappedValue was accessed before the `Component` was configured.
+                Only access dependencies once the component has been configured and the CardinalKit initialization is complete.
+                """
+            )
+        }
+        return standard
+    }
+    
+    
+    /// Refer to ``Component/SharedStandard`` for information on how to use the `@SharedStandard` property wrapper. Do not use the `_StandardPropertyWrapper` directly.
+    public init() { }
+    
+    
+    func inject(standard: S) {
+        self.standard = standard
+    }
+}

--- a/Sources/CardinalKit/Standard/StandardPropertyWrapper.swift
+++ b/Sources/CardinalKit/Standard/StandardPropertyWrapper.swift
@@ -9,7 +9,7 @@
 import XCTRuntimeAssertions
 
 
-/// Refer to ``Component/SharedStandard`` for information on how to use the `@SharedStandard` property wrapper. Do not use the `_StandardPropertyWrapper` directly.
+/// Refer to ``Component/StandardActor`` for information on how to use the `@StandardActor` property wrapper. Do not use the `_StandardPropertyWrapper` directly.
 @propertyWrapper
 public class _StandardPropertyWrapper<S: Standard> {
     // swiftlint:disable:previous type_name
@@ -33,7 +33,7 @@ public class _StandardPropertyWrapper<S: Standard> {
     }
     
     
-    /// Refer to ``Component/SharedStandard`` for information on how to use the `@SharedStandard` property wrapper. Do not use the `_StandardPropertyWrapper` directly.
+    /// Refer to ``Component/StandardActor`` for information on how to use the `@StandardActor` property wrapper. Do not use the `_StandardPropertyWrapper` directly.
     public init() { }
     
     

--- a/Tests/CardinalKitTests/CapabilityTests/Dependencies/DependencyTests.swift
+++ b/Tests/CardinalKitTests/CapabilityTests/Dependencies/DependencyTests.swift
@@ -12,7 +12,7 @@ import XCTest
 import XCTRuntimeAssertions
 
 
-private struct TestStandard: Standard {}
+private actor TestStandard: Standard {}
 
 private class TestComponent1<ComponentStandard: Standard>: Component {
     @Dependency var testComponent2 = TestComponent2<ComponentStandard>()

--- a/Tests/CardinalKitTests/CapabilityTests/LifecycleTests/LifecycleTests.swift
+++ b/Tests/CardinalKitTests/CapabilityTests/LifecycleTests/LifecycleTests.swift
@@ -12,6 +12,9 @@ import XCTRuntimeAssertions
 
 
 private class TestLifecycleHandler: Component, LifecycleHandler, TypedCollectionKey {
+    typealias ComponentStandard = MockStandard
+    
+    
     let expectationWillFinishLaunchingWithOption: XCTestExpectation
     let expectationApplicationWillTerminate: XCTestExpectation
     
@@ -19,11 +22,6 @@ private class TestLifecycleHandler: Component, LifecycleHandler, TypedCollection
     init(expectationWillFinishLaunchingWithOption: XCTestExpectation, expectationApplicationWillTerminate: XCTestExpectation) {
         self.expectationWillFinishLaunchingWithOption = expectationWillFinishLaunchingWithOption
         self.expectationApplicationWillTerminate = expectationApplicationWillTerminate
-    }
-    
-    
-    func configure(cardinalKit: CardinalKit<MockStandard>) {
-        cardinalKit.typedCollection.set(Self.self, to: self)
     }
     
     
@@ -41,9 +39,7 @@ private class TestLifecycleHandler: Component, LifecycleHandler, TypedCollection
 
 
 private class EmpfyLifecycleHandler: Component, LifecycleHandler, TypedCollectionKey {
-    func configure(cardinalKit: CardinalKit<MockStandard>) {
-        cardinalKit.typedCollection.set(Self.self, to: self)
-    }
+    typealias ComponentStandard = MockStandard
 }
 
 private class TestLifecycleHandlerApplicationDelegate: CardinalKitAppDelegate {

--- a/Tests/CardinalKitTests/Shared/MockStandard.swift
+++ b/Tests/CardinalKitTests/Shared/MockStandard.swift
@@ -10,7 +10,12 @@
 import CardinalKit
 
 
-public struct MockStandard: Standard {
+public actor MockStandard: Standard {
     public init() {}
+    
+    
+    func fulfill(expectation: XCTestExpectation) {
+        expectation.fulfill()
+    }
 }
 #endif

--- a/Tests/CardinalKitTests/Shared/TestComponent.swift
+++ b/Tests/CardinalKitTests/Shared/TestComponent.swift
@@ -20,8 +20,7 @@ public class TestComponent<ComponentStandard: Standard>: ObservableObject, Compo
     }
     
     
-    public func configure(cardinalKit: CardinalKit<ComponentStandard>) {
-        cardinalKit.typedCollection.set(TestComponent.self, to: self)
+    public func configure() {
         expectation.fulfill()
     }
 }

--- a/Tests/CardinalKitTests/StandardTests/StandardTests.swift
+++ b/Tests/CardinalKitTests/StandardTests/StandardTests.swift
@@ -61,4 +61,10 @@ final class StandardTests: XCTestCase {
         
         wait(for: [expectation], timeout: 0.01)
     }
+    
+    func testInjectionPrecondition() throws {
+        try XCTRuntimePrecondition {
+            _ = _StandardPropertyWrapper<MockStandard>().wrappedValue
+        }
+    }
 }

--- a/Tests/CardinalKitTests/StandardTests/StandardTests.swift
+++ b/Tests/CardinalKitTests/StandardTests/StandardTests.swift
@@ -1,0 +1,64 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@testable import CardinalKit
+import SwiftUI
+import XCTest
+import XCTRuntimeAssertions
+
+
+final class StandardTests: XCTestCase {
+    class StandardInjectionTestComponent: Component {
+        typealias ComponentStandard = MockStandard
+        
+        
+        @SharedStandard var standard: MockStandard
+        let expectation: XCTestExpectation
+        
+        
+        init(expectation: XCTestExpectation) {
+            self.expectation = expectation
+        }
+        
+        
+        func configure() {
+            Task {
+                await standard.fulfill(expectation: expectation)
+            }
+        }
+    }
+    
+    class StandardInjectionTestApplicationDelegate: CardinalKitAppDelegate {
+        let expectation: XCTestExpectation
+        
+        
+        override var configuration: Configuration {
+            Configuration(standard: MockStandard()) {
+                StandardInjectionTestComponent(expectation: expectation)
+            }
+        }
+        
+        
+        init(expectation: XCTestExpectation) {
+            self.expectation = expectation
+        }
+    }
+    
+    
+    func testComponentFlow() async throws {
+        let expectation = XCTestExpectation(description: "Component")
+        expectation.assertForOverFulfill = true
+        
+        let standardInjectionTestApplicationDelegate = await StandardInjectionTestApplicationDelegate(
+            expectation: expectation
+        )
+        _ = await standardInjectionTestApplicationDelegate.cardinalKit
+        
+        wait(for: [expectation], timeout: 0.01)
+    }
+}

--- a/Tests/CardinalKitTests/StandardTests/StandardTests.swift
+++ b/Tests/CardinalKitTests/StandardTests/StandardTests.swift
@@ -17,7 +17,7 @@ final class StandardTests: XCTestCase {
         typealias ComponentStandard = MockStandard
         
         
-        @SharedStandard var standard: MockStandard
+        @StandardActor var standard: MockStandard
         let expectation: XCTestExpectation
         
         

--- a/Tests/LocalStorageTests/LocalStorageTests.swift
+++ b/Tests/LocalStorageTests/LocalStorageTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 
 final class LocalStorageTests: XCTestCase {
-    struct LocalStorageTestStandard: Standard {}
+    actor LocalStorageTestStandard: Standard {}
     
     struct Letter: Codable, Equatable {
         let greeting: String

--- a/Tests/UITests/TestApp/Shared/TestAppStandard.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppStandard.swift
@@ -9,4 +9,4 @@
 import CardinalKit
 
 
-struct TestAppStandard: Standard {}
+actor TestAppStandard: Standard {}

--- a/Tests/UITests/UITests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Tests/UITests/UITests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:/Users/paulshmiedmayer/Downloads/CardinalKitSPM/Example/UITests.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
# The Standard Actor

## :recycle: Current situation & Problem
A standard currently only provides a constraint for Components. In light of the creation of concrete Standards, e.g. a FHIR standard we want to enable the Standard to be used by components and to be accessible in a safe way when dealing with concurrent code.

## :bulb: Proposed solution
The constraint a `Standard` to be an `actor` and enable the injection of the currently used `Standard` in a `Component` using the `@StandardActor` property wrapper. 

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

