### PR TITLE
Improve test stability

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -63,6 +63,7 @@ jobs:
       destination: ${{ matrix.platform.destination }}
       resultBundle: ${{ format('TestApp-{0}-{1}.xcresult', matrix.platform.name, matrix.config) }}
       artifactname: ${{ format('TestApp-{0}-{1}.xcresult', matrix.platform.name, matrix.config) }}
+      xcodeversion: '26.0.1'
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: [package_tests, ui_tests]

--- a/Tests/SpeziTests/CapabilityTests/LifecycleTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/LifecycleTests.swift
@@ -58,12 +58,12 @@ private class TestLifecycleHandlerApplicationDelegate: SpeziAppDelegate {
 }
 
 
-@Suite("Lifecycle")
+@MainActor
+@Suite("Lifecycle", .serialized)
 struct LifecycleTests {
-    @MainActor
     @available(*, deprecated, message: "Propagate deprecation warning")
     @Test("UIApplication Lifecycle Methods")
-    func testUIApplicationLifecycleMethods() async throws {
+    func uiApplicationLifecycleMethods() async throws {
         let module = TestLifecycleHandler()
         let testApplicationDelegate = TestLifecycleHandlerApplicationDelegate(injectedModule: module)
 

--- a/Tests/SpeziTests/CapabilityTests/ModuleCommunicationTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/ModuleCommunicationTests.swift
@@ -40,6 +40,7 @@ private final class CollectModule: Module {
 }
 
 
+@MainActor
 @Suite("Module Communication", .serialized)
 struct ModuleCommunicationTests {
     private class TestApplicationDelegate: SpeziAppDelegate {
@@ -51,19 +52,18 @@ struct ModuleCommunicationTests {
         }
     }
 
-    @MainActor private static var provideModule = ProvideModule1()
-    @MainActor private static var collectModule = CollectModule()
+    private static var provideModule = ProvideModule1()
+    private static var collectModule = CollectModule()
 
 
-    @MainActor
     init() async throws {
         Self.provideModule = ProvideModule1()
         Self.collectModule = CollectModule()
     }
 
-    @MainActor
+
     @Test("Simple Communication")
-    func testSimpleCommunication() throws {
+    func simpleCommunication() throws {
         let delegate = TestApplicationDelegate()
         _ = delegate.spezi // ensure init
 

--- a/Tests/SpeziTests/CapabilityTests/NotificationsTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/NotificationsTests.swift
@@ -93,12 +93,12 @@ private class TestNotificationApplicationDelegate: SpeziAppDelegate {
 }
 
 
-@Suite("Notifications")
+@MainActor
+@Suite("Notifications", .serialized)
 struct NotificationsTests {
-    @MainActor
     @Test("Register Notifications Successfully")
     @available(*, deprecated, message: "Forward deprecation warnings")
-    func testRegisterNotificationsSuccessful() async throws {
+    func registerNotificationsSuccessful() async throws {
         let module = TestNotificationHandler()
         let delegate = TestNotificationApplicationDelegate(module)
         _ = delegate.spezi // init spezi
@@ -124,10 +124,9 @@ struct NotificationsTests {
         #expect(module.lastDeviceToken == data)
     }
 
-    @MainActor
     @Test("Register Notifications Erroneous")
     @available(*, deprecated, message: "Forward deprecation warnings")
-    func testRegisterNotificationsErroneous() async throws {
+    func registerNotificationsErroneous() async throws {
         enum TestError: Error, Equatable {
             case testError
         }
@@ -140,7 +139,7 @@ struct NotificationsTests {
 
         async let registration = action()
 
-        try await Task.sleep(for: .milliseconds(250)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(750)) // allow dispatch of Task above
 
 #if os(iOS) || os(visionOS) || os(tvOS)
         delegate.application(UIApplication.shared, didFailToRegisterForRemoteNotificationsWithError: TestError.testError)
@@ -150,7 +149,7 @@ struct NotificationsTests {
         delegate.application(NSApplication.shared, didFailToRegisterForRemoteNotificationsWithError: TestError.testError)
 #endif
 
-        try await Task.sleep(for: .milliseconds(250)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(750)) // allow dispatch of Task above
 
         do {
             _ = try await registration
@@ -162,10 +161,9 @@ struct NotificationsTests {
         }
     }
 
-    @MainActor
     @Test("Unregister Notifications")
     @available(*, deprecated, message: "Forward deprecation warnings")
-    func testUnregisterNotifications() async throws {
+    func unregisterNotifications() async throws {
         let module = TestNotificationHandler()
         let delegate = TestNotificationApplicationDelegate(module)
         _ = delegate.spezi // init spezi
@@ -174,10 +172,9 @@ struct NotificationsTests {
         action()
     }
 
-    @MainActor
     @Test("Remote Notification delivers no Data")
     @available(*, deprecated, message: "Forward deprecation warnings")
-    func testRemoteNotificationDeliveryNoData() async {
+    func remoteNotificationDeliveryNoData() async {
         await confirmation { confirmation in
             let module = TestNotificationHandler(remoteNotificationConfirmation: confirmation)
             let delegate = TestNotificationApplicationDelegate(module)
@@ -197,10 +194,9 @@ struct NotificationsTests {
         }
     }
 
-    @MainActor
     @Test("Remote Notifications delivers Data")
     @available(*, deprecated, message: "Forward deprecation warnings")
-    func testRemoteNotificationDeliveryNewData() async throws {
+    func remoteNotificationDeliveryNewData() async throws {
         await confirmation { confirmation in
             let module = TestNotificationHandler(remoteNotificationConfirmation: confirmation)
 #if !os(macOS)
@@ -224,10 +220,9 @@ struct NotificationsTests {
         }
     }
 
-    @MainActor
     @Test("Remote Notifications Delivery Failed")
     @available(*, deprecated, message: "Forward deprecation warnings")
-    func testRemoteNotificationDeliveryFailed() async {
+    func remoteNotificationDeliveryFailed() async {
         await confirmation { confirmation in
             let module = TestNotificationHandler(remoteNotificationConfirmation: confirmation)
 #if !os(macOS)

--- a/Tests/SpeziTests/CapabilityTests/NotificationsTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/NotificationsTests.swift
@@ -106,7 +106,7 @@ struct NotificationsTests {
         let action = module.registerRemoteNotifications
 
         async let registration = action()
-        try await Task.sleep(for: .milliseconds(250)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(750)) // allow dispatch of Task above
 
         let data = try #require("Hello World".data(using: .utf8))
 
@@ -118,7 +118,7 @@ struct NotificationsTests {
         delegate.application(NSApplication.shared, didRegisterForRemoteNotificationsWithDeviceToken: data)
 #endif
 
-        try await Task.sleep(for: .milliseconds(250)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(750)) // allow dispatch of Task above
 
         _ = try await registration
         #expect(module.lastDeviceToken == data)
@@ -139,7 +139,7 @@ struct NotificationsTests {
 
         async let registration = action()
 
-        try await Task.sleep(for: .milliseconds(750)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(250)) // allow dispatch of Task above
 
 #if os(iOS) || os(visionOS) || os(tvOS)
         delegate.application(UIApplication.shared, didFailToRegisterForRemoteNotificationsWithError: TestError.testError)
@@ -149,7 +149,7 @@ struct NotificationsTests {
         delegate.application(NSApplication.shared, didFailToRegisterForRemoteNotificationsWithError: TestError.testError)
 #endif
 
-        try await Task.sleep(for: .milliseconds(750)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(250)) // allow dispatch of Task above
 
         do {
             _ = try await registration

--- a/Tests/SpeziTests/CapabilityTests/ViewModifierTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/ViewModifierTests.swift
@@ -11,11 +11,11 @@ import SwiftUI
 import Testing
 
 
-@Suite("ViewModifier")
+@MainActor
+@Suite("ViewModifier", .serialized)
 struct ViewModifierTests {
-    @MainActor
     @Test("ViewModifier Retrieval")
-    func testViewModifierRetrieval() async {
+    func viewModifierRetrieval() async {
         await confirmation { confirmation in
             let testApplicationDelegate = TestApplicationDelegate(confirmation: confirmation)
 
@@ -30,8 +30,8 @@ struct ViewModifierTests {
         }
     }
 
-    @MainActor
-    func testEmptyRetrieval() {
+    @Test
+    func emptyRetrieval() {
         let speziAppDelegate = SpeziAppDelegate()
         #expect(speziAppDelegate.spezi.viewModifiers.isEmpty)
     }

--- a/Tests/SpeziTests/DependenciesTests/DependencyBuilderTests.swift
+++ b/Tests/SpeziTests/DependenciesTests/DependencyBuilderTests.swift
@@ -30,10 +30,10 @@ class ExampleDependencyModule: Module {
     }
 }
 
-@Suite
+@MainActor
+@Suite(.serialized)
 struct DependencyBuilderTests {
     @Test
-    @MainActor
     func dependencyCollection() {
         var collection = DependencyCollection(ExampleDependentModule())
         #expect(collection.count == 1)
@@ -45,7 +45,6 @@ struct DependencyBuilderTests {
     
     @Test
     @available(*, deprecated, message: "Propagate deprecation warning.")
-    @MainActor
     func deprecatedInits() {
         let collection1 = DependencyCollection(singleEntry: ExampleDependentModule())
         let collection2 = DependencyCollection(singleEntry: {
@@ -57,7 +56,6 @@ struct DependencyBuilderTests {
 
 
     @Test
-    @MainActor
     func dependencyBuilder() throws {
         let module = ExampleDependencyModule {
             ExampleDependentModule()

--- a/Tests/SpeziTests/DependenciesTests/DependencyContextTests.swift
+++ b/Tests/SpeziTests/DependenciesTests/DependencyContextTests.swift
@@ -12,7 +12,7 @@ import Testing
 
 private final class ExampleModule: Module {}
 
-@Suite
+@Suite(.serialized)
 struct DependencyContextTests {
     @Test
     func injectionPreconditionDependencyPropertyWrapper() throws {

--- a/Tests/SpeziTests/DependenciesTests/DependencyTests.swift
+++ b/Tests/SpeziTests/DependenciesTests/DependencyTests.swift
@@ -192,7 +192,7 @@ func getModule<M: Module>(_ module: M.Type = M.self, in modules: [any Module]) t
 }
 
 @MainActor
-@Suite("Dependency Tests")
+@Suite("Dependency Tests", .serialized)
 struct DependencyTests { // swiftlint:disable:this type_body_length
     @Test
     func loadingAdditionalDependency() throws {

--- a/Tests/SpeziTests/DependenciesTests/DynamicDependenciesTests.swift
+++ b/Tests/SpeziTests/DependenciesTests/DynamicDependenciesTests.swift
@@ -85,9 +85,9 @@ private final class TestModule2: Module {}
 private final class TestModule3: Module {}
 
 
-@Suite
+@MainActor
+@Suite(.serialized)
 struct DynamicDependenciesTests {
-    @MainActor
     @Test
     func dynamicDependencies() throws {
         for dynamicDependenciesTestCase in DynamicDependenciesTestCase.allCases {

--- a/Tests/SpeziTests/ModuleTests/ModuleBuilderTests.swift
+++ b/Tests/SpeziTests/ModuleTests/ModuleBuilderTests.swift
@@ -10,7 +10,7 @@
 import Testing
 
 @MainActor
-@Suite
+@Suite(.serialized)
 struct ModuleBuilderTests {
     private struct ModuleBuilderExpectations {
         let firstTestExpectation: TestExpectation

--- a/Tests/SpeziTests/ModuleTests/ModuleTests.swift
+++ b/Tests/SpeziTests/ModuleTests/ModuleTests.swift
@@ -29,20 +29,19 @@ private final class DependingTestModule: Module {
 }
 
 
-@Suite("Module")
+@MainActor
+@Suite("Module", .serialized)
 struct ModuleTests {
-    @MainActor
     @Test("Module Flow")
-    func testModuleFlow() async {
+    func moduleFlow() async {
         await confirmation { confirmation in
             _ = Text("Spezi")
                 .spezi(TestApplicationDelegate(confirmation: confirmation))
         }
     }
 
-    @MainActor
     @Test("Spezi")
-    func testSpezi() throws {
+    func spezi() throws {
         let spezi = Spezi(standard: DefaultStandard(), modules: [DependingTestModule()])
 
         let modules = spezi.modules
@@ -52,9 +51,8 @@ struct ModuleTests {
         #expect(modules.contains(where: { $0 is TestModule }))
     }
 
-    @MainActor
     @Test("Preview Modifier")
-    func testPreviewModifier() async throws {
+    func previewModifier() async throws {
         // manually patch environment variable for running within Xcode preview window
         setenv(ProcessInfo.xcodeRunningForPreviewKey, "1", 1)
 
@@ -70,9 +68,8 @@ struct ModuleTests {
         unsetenv(ProcessInfo.xcodeRunningForPreviewKey)
     }
 
-    @MainActor
     @Test("Module Creation")
-    func testModuleCreation() async {
+    func moduleCreation() async {
         await confirmation { moduleConfirmation in
             await confirmation { dependencyConfirmation in
                 let module = DependingTestModule(confirmation: moduleConfirmation, dependencyConfirmation: dependencyConfirmation)

--- a/Tests/SpeziTests/StandardTests/StandardConstraintTests.swift
+++ b/Tests/SpeziTests/StandardTests/StandardConstraintTests.swift
@@ -14,7 +14,7 @@ private protocol ExampleConstraint: Standard {
 }
 
 @MainActor
-@Suite
+@Suite(.serialized)
 struct StandardConstraintTests {
     final class StandardCTestModule: Module {
         @StandardActor private var standard: any ExampleConstraint

--- a/Tests/SpeziTests/StandardTests/StandardInjectionTests.swift
+++ b/Tests/SpeziTests/StandardTests/StandardInjectionTests.swift
@@ -11,7 +11,7 @@ import RuntimeAssertionsTesting
 import SwiftUI
 import Testing
 
-@Suite
+@Suite(.serialized)
 struct StandardInjectionTests {
     final class StandardInjectionTestModule: Module {
         @StandardActor var standard: MockStandard

--- a/Tests/SpeziTests/StandardTests/StandardUnfulfilledConstraintTests.swift
+++ b/Tests/SpeziTests/StandardTests/StandardUnfulfilledConstraintTests.swift
@@ -16,6 +16,8 @@ private protocol UnfulfilledExampleConstraint: Standard {
 }
 
 
+@MainActor
+@Suite(.serialized)
 struct StandardUnfulfilledConstraintTests {
     final class StandardUCTestModule: Module {
         @StandardActor private var standard: any UnfulfilledExampleConstraint
@@ -28,7 +30,6 @@ struct StandardUnfulfilledConstraintTests {
     }
     
     @Test
-    @MainActor
     func standardUnfulfilledConstraint() throws {
         let configuration = Configuration(standard: MockStandard()) {}
         let spezi = Spezi(from: configuration)

--- a/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
+++ b/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
@@ -77,14 +77,14 @@ final class LifecycleHandlerTests: XCTestCase {
         app.activate()
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
-        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 2.0))
+        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 7.5))
 
 #if os(visionOS)
         springboard.launch() // springboard is in `runningBackgroundSuspended` state on visionOS. So we need to launch it not just activate
 #else
         springboard.activate()
 #endif
-        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 2.0))
+        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 7.5))
 
         app.launch()
 

--- a/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
+++ b/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
@@ -63,7 +63,7 @@ final class LifecycleHandlerTests: XCTestCase {
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
 
-        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 10.0))
+        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 15.0))
 
         let springboard = XCUIApplication(bundleIdentifier: XCUIApplication.homeScreenBundle)
 #if os(visionOS)
@@ -72,7 +72,7 @@ final class LifecycleHandlerTests: XCTestCase {
         springboard.activate()
 #endif
 
-        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 10.0))
+        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 15.0))
 
         app.activate()
 

--- a/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
+++ b/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
@@ -63,7 +63,7 @@ final class LifecycleHandlerTests: XCTestCase {
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
 
-        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 2.0))
+        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 5.0))
 
         let springboard = XCUIApplication(bundleIdentifier: XCUIApplication.homeScreenBundle)
 #if os(visionOS)
@@ -72,19 +72,19 @@ final class LifecycleHandlerTests: XCTestCase {
         springboard.activate()
 #endif
 
-        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 2.0))
+        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 5.0))
 
         app.activate()
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
-        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 7.5))
+        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 5.0))
 
 #if os(visionOS)
         springboard.launch() // springboard is in `runningBackgroundSuspended` state on visionOS. So we need to launch it not just activate
 #else
         springboard.activate()
 #endif
-        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 7.5))
+        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 5.0))
 
         app.launch()
 

--- a/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
+++ b/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
@@ -63,7 +63,7 @@ final class LifecycleHandlerTests: XCTestCase {
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
 
-        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 5.0))
+        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 10.0))
 
         let springboard = XCUIApplication(bundleIdentifier: XCUIApplication.homeScreenBundle)
 #if os(visionOS)
@@ -72,12 +72,12 @@ final class LifecycleHandlerTests: XCTestCase {
         springboard.activate()
 #endif
 
-        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 5.0))
+        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 10.0))
 
         app.activate()
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
-        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 5.0))
+        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 10.0))
 
 #if os(visionOS)
         springboard.launch() // springboard is in `runningBackgroundSuspended` state on visionOS. So we need to launch it not just activate


### PR DESCRIPTION
# *Improve test stability*

## :recycle: Current situation & Problem
- Two tests are flaky: visionOS UI tests (failing on launch options) and Notification unit tests across platforms (mostly visionOS)
- Increased timeouts and made all test suites run serially to reduce issues caused by parallel execution

## :gear: Release Notes
- Improve test stability

## :pencil: Code of Conduct & Contributing Guidelines
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
