### PR TITLE
support optionals in `@StandardActor`

### DIFF
--- a/Sources/Spezi/Standard/Module+Standard.swift
+++ b/Sources/Spezi/Standard/Module+Standard.swift
@@ -18,6 +18,15 @@ extension Module {
     /// ```swift
     /// class ExampleModule: Module {
     ///     @StandardActor var standard: ExampleStandard
+    ///
+    ///     // You can omit the type to get an `any Standard`:
+    ///     @StandardActor var standard
+    ///
+    ///     // You also can specify a protocol to cast the standard to a constraint:
+    ///     @StandardActor var standard: any HealthKitConstraint
+    ///
+    ///     // And you can make the type optional if the app isn't required to conform its standard to the protocol:
+    ///     @StandardActor var standard: (any HealthKitConstraint)?
     /// }
     /// ```
     public typealias StandardActor = _StandardPropertyWrapper

--- a/Sources/Spezi/Standard/StandardPropertyWrapper.swift
+++ b/Sources/Spezi/Standard/StandardPropertyWrapper.swift
@@ -15,8 +15,13 @@ public class _StandardPropertyWrapper<Constraint> {
     // swiftlint:disable:previous type_name
     // We want the _StandardPropertyWrapper type to be hidden from autocompletion and document generation.
     
-    private var standard: Constraint?
+    private enum LoadResult {
+        case success(Constraint)
+        case failure
+    }
     
+    private let load: (any Standard) -> LoadResult
+    private var standard: Constraint?
     
     /// The injected ``Standard`` that is resolved by ``Spezi/Spezi``.
     public var wrappedValue: Constraint {
@@ -31,23 +36,51 @@ public class _StandardPropertyWrapper<Constraint> {
         return standard
     }
     
-    
     /// Refer to ``Module/StandardActor`` for information on how to use the `@StandardActor` property wrapper. Do not use the `_StandardPropertyWrapper` directly.
-    public init(_ constraint: Constraint.Type = Constraint.self) {}
+    @_disfavoredOverload // needs to be downranked bc otherwise the optional init below would never get picked.
+    public init(_ constraint: Constraint.Type = Constraint.self) {
+        load = { (standard: any Standard) -> LoadResult in
+            if let constraint = standard as? Constraint {
+                .success(constraint)
+            } else {
+                .failure
+            }
+        }
+    }
+    
+    /// Equivalent to `@StandardActor var standard: any Standard`.
+    public convenience init() where Constraint == any Standard {
+        self.init((any Standard).self)
+    }
+    
+    /// Creates an `@StandardActor` with an optional constraint.
+    ///
+    /// If the standard does not conform to the protocol, the resulting property value is `nil`.
+    ///
+    /// ```swift
+    /// @StandardActor var standard: (any HealthKitConstraint)?
+    /// ```
+    public init<C>(_ constraint: C.Type = C.self) where Constraint == C? {
+        load = { (standard: any Standard) -> LoadResult in
+            .success(standard as? C)
+        }
+    }
 }
 
 
 extension _StandardPropertyWrapper: SpeziPropertyWrapper {
     func inject(spezi: Spezi) throws(SpeziPropertyError) {
-        guard let standard = spezi.standard as? Constraint else {
+        // (lldb) po Constraint.self is any AnyOptional.Type
+        switch load(spezi.standard) {
+        case .success(let standard):
+            self.standard = standard
+        case .failure:
             let standardType = type(of: spezi.standard)
             throw SpeziPropertyError.unsatisfiedStandardConstraint(
                 constraint: String(describing: Constraint.self),
                 standard: String(describing: standardType)
             )
         }
-
-        self.standard = standard
     }
 
     func clear() {

--- a/Sources/Spezi/Standard/StandardPropertyWrapper.swift
+++ b/Sources/Spezi/Standard/StandardPropertyWrapper.swift
@@ -70,7 +70,6 @@ public class _StandardPropertyWrapper<Constraint> {
 
 extension _StandardPropertyWrapper: SpeziPropertyWrapper {
     func inject(spezi: Spezi) throws(SpeziPropertyError) {
-        // (lldb) po Constraint.self is any AnyOptional.Type
         switch load(spezi.standard) {
         case .success(let standard):
             self.standard = standard

--- a/Tests/SpeziTests/CapabilityTests/NotificationsTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/NotificationsTests.swift
@@ -141,7 +141,7 @@ struct NotificationsTests {
 
         async let registration = action()
 
-        try await Task.sleep(for: .milliseconds(250)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(500)) // allow dispatch of Task above
 
 #if os(iOS) || os(visionOS) || os(tvOS)
         delegate.application(UIApplication.shared, didFailToRegisterForRemoteNotificationsWithError: TestError.testError)
@@ -151,7 +151,7 @@ struct NotificationsTests {
         delegate.application(NSApplication.shared, didFailToRegisterForRemoteNotificationsWithError: TestError.testError)
 #endif
 
-        try await Task.sleep(for: .milliseconds(250)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(500)) // allow dispatch of Task above
 
         do {
             _ = try await registration

--- a/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
+++ b/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
@@ -61,9 +61,9 @@ final class LifecycleHandlerTests: XCTestCase {
         app.launchArguments = ["--lifecycleTests"]
         app.launch()
 
-        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 4.0))
 
-        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 2.0))
+        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 4.0))
 
         let springboard = XCUIApplication(bundleIdentifier: XCUIApplication.homeScreenBundle)
 #if os(visionOS)
@@ -72,23 +72,23 @@ final class LifecycleHandlerTests: XCTestCase {
         springboard.activate()
 #endif
 
-        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 2.0))
+        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 4.0))
 
         app.activate()
 
-        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
-        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 2.0))
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 4.0))
+        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 4.0))
 
 #if os(visionOS)
         springboard.launch() // springboard is in `runningBackgroundSuspended` state on visionOS. So we need to launch it not just activate
 #else
         springboard.activate()
 #endif
-        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 2.0))
+        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 4.0))
 
         app.launch()
 
-        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
-        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 2.0))
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 4.0))
+        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 4.0))
     }
 }


### PR DESCRIPTION
# support optionals in `@StandardActor`

## :recycle: Current situation & Problem
see #144
fixes #144


## :gear: Release Notes
- `@StandardActor`:
    - now supports optional constraints (`@StandardActor var standard: (any HealthKitConstraint)?`
    - now supports omitting the constraint, as a shorthand for `any Standard` (`@StandardActor var standard`)


## :books: Documentation
yes


## :white_check_mark: Testing
yes


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
