### PR TITLE
support SE-470

### DIFF
--- a/Sources/Spezi/Dependencies/Property/DependencyPropertyWrapper.swift
+++ b/Sources/Spezi/Dependencies/Property/DependencyPropertyWrapper.swift
@@ -30,7 +30,7 @@ private protocol ModuleArrayDependency {
 
 /// Refer to the documentation of ``Module/Dependency`` for information on how to use the `@Dependency` property wrapper.
 @propertyWrapper
-public class _DependencyPropertyWrapper<Value> { // swiftlint:disable:this type_name
+public final class _DependencyPropertyWrapper<Value> { // swiftlint:disable:this type_name
     private weak var spezi: Spezi?
     private let dependencies: DependencyCollection
 

--- a/Sources/Spezi/Module/Module.swift
+++ b/Sources/Spezi/Module/Module.swift
@@ -9,7 +9,7 @@
 
 // note: detailed documentation is provided as an article extension in the DocC bundle
 /// A `Module` defines a software subsystem that can be configured as part of the ``SpeziAppDelegate/configuration``.
-public protocol Module: AnyObject {
+public protocol Module: AnyObject, SendableMetatype {
     /// Called on the initialization of the Spezi instance to perform a lightweight configuration of the module.
     ///
     /// It is advised that longer setup tasks are done in an asynchronous task and started during the call of the configure method.


### PR DESCRIPTION
# support SE-470

## :recycle: Current situation & Problem
[SE-470](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0470-isolated-conformances.md)'s inferred global-actor-isolated conformances currently don't work with Spezi modules, since a MainActor-isolated module's `Module` conformance in that case will also become MainActor-isolated, making it impossible to use `@Dependency` to pull in the module into a non-MainActor-isolated module, even though the resulting property would be correctly MainActor-isolated.

simplified example:
```swift
@MainActor
final class ModuleA: Module, Sendable {}

final class ModuleB: Module {
    @Dependency(ModuleA.self) var moduleA // <-- error: main actor-isolated default value in a nonisolated context
    
    nonisolated init() {}
}
```

in this example, `ModuleA`'s conformance to the `Module` protocol is MainActor-isolated, but the `@Dependency` property wrapper (which is nonisolated) needs to capture the metatype.

we fix this by having `Module` inherit from `SendableMetatype`. additionally, we also make the `_DependencyPropertyWrapper` class final, bc there really is no reason for it not to be.


## :gear: Release Notes
- the `Module` protocol now inherits from `SendableMetatype`, allowing client code to enable inferred global actor-isolated conformances without having to define all modules as `class MyModule: nonisolated Module`


## :books: Documentation
n/a; this should not require any changes to existing modules.


## :white_check_mark: Testing
i tried writing a test case that would fail to compile if the `SendableMetatype` inheritance is missing (ie, that reproduces the issue being fixed here), but i failed to do so. it seems that this error only occurs if multiple packages are involved (ie, if the module used in the `@Dependency(...)` declaration is from a different package than the module containing the `@Dependency`.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
