### PR TITLE
fix weird 26.4 compile issue

### DIFF
--- a/Sources/Spezi/Spezi/Spezi+Preview.swift
+++ b/Sources/Spezi/Spezi/Spezi+Preview.swift
@@ -71,29 +71,31 @@ extension View {
         standard: S,
         simulateLifecycle: LifecycleSimulationOptions = .disabled,
         @ModuleBuilder _ modules: () -> ModuleCollection
-    ) -> some View {
+    ) -> AnyView {
         precondition(
             ProcessInfo.processInfo.isPreviewSimulator,
             "The Spezi previewWith(standard:_:) modifier can only used within Xcode preview processes."
         )
-
         var storage = SpeziStorage()
         if case let .launchWithOptions(options) = simulateLifecycle {
             storage[LaunchOptionsKey.self] = options
         }
-
         let spezi = Spezi(standard: standard, modules: modules().elements, storage: storage)
-
-        return modifier(SpeziViewModifier(spezi))
+        var view: AnyView = self
+            .modifier(SpeziViewModifier(spezi))
             .task(spezi.run)
+            .intoAnyView()
 #if os(iOS) || os(visionOS) || os(tvOS)
+        view = view
             .task { @MainActor in
                 if case let .launchWithOptions(options) = simulateLifecycle {
                     (spezi as any DeprecatedLaunchOptionsCall)
                         .callWillFinishLaunching(UIApplication.shared, launchOptions: options)
                 }
             }
+            .intoAnyView()
 #endif
+        return view
     }
 
     /// Configure Spezi for your previews using a collection of Modules.
@@ -114,6 +116,11 @@ extension View {
         @ModuleBuilder _ modules: () -> ModuleCollection
     ) -> some View {
         previewWith(standard: DefaultStandard(), simulateLifecycle: simulateLifecycle, modules)
+    }
+    
+    
+    private func intoAnyView() -> AnyView {
+        AnyView(self)
     }
 }
 #endif

--- a/Sources/Spezi/Spezi/Spezi+Preview.swift
+++ b/Sources/Spezi/Spezi/Spezi+Preview.swift
@@ -81,21 +81,18 @@ extension View {
             storage[LaunchOptionsKey.self] = options
         }
         let spezi = Spezi(standard: standard, modules: modules().elements, storage: storage)
-        var view: AnyView = self
+        return self
             .modifier(SpeziViewModifier(spezi))
             .task(spezi.run)
-            .intoAnyView()
 #if os(iOS) || os(visionOS) || os(tvOS)
-        view = view
             .task { @MainActor in
                 if case let .launchWithOptions(options) = simulateLifecycle {
                     (spezi as any DeprecatedLaunchOptionsCall)
                         .callWillFinishLaunching(UIApplication.shared, launchOptions: options)
                 }
             }
-            .intoAnyView()
 #endif
-        return view
+            .intoAnyView()
     }
 
     /// Configure Spezi for your previews using a collection of Modules.


### PR DESCRIPTION
# fix weird 26.4 compile issue

## :recycle: Current situation & Problem
there is an issue, where using Spezi's `previewWith { ... }` view modifier within a `PreviewModifier` and compiling a release build against the 26.4 SDK, will fail with a linker error complaining that it can't find the `View.task` function.

this seems to be caused by the `task` modifier possibly having been relocated into SwiftUICore, but i'm not 100% sure.

this PR fixes this, by making the `previewWith` return type an `AnyView` instead of an opaque type.
since this is a testing-only thing, using the `AnyView` here will be fine.


## :gear: Release Notes
- fixed compile issue when using `previewWith` in a `PreviewModifer` and compiling a release build against the 26.4 SDK


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
